### PR TITLE
ISC Charter: Replace PDF version with HTML version

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -20,8 +20,8 @@ website:
             href: about/governance.qmd
           - text: Bylaws (PDF)
             href: rc-docs/R-Consortium-Bylaws-7-9-2024.pdf
-          - text: ISC Charter (PDF)
-            href: rc-docs/ISC-Charter-08-13-24.pdf
+          - text: ISC Charter
+            href: governance/isc-charter.html
           - text: Marketing Committee Charter (PDF)
             href: rc-docs/R-Consortium-Marketing-Committee-Charter-2021-10-27.pdf
           - text: FAQ

--- a/governance/isc-charter.md
+++ b/governance/isc-charter.md
@@ -1,0 +1,108 @@
+---
+title: "R Consortium Infrastructure Steering Committee Charter"
+date: 2023-08-11
+number-sections: false
+---
+
+# R Consortium Infrastructure Steering Committee Charter
+
+## 1. Mission of the Infrastructure Steering Committee
+
+The mission and goals of the Infrastructure Steering Committee include the following activities:
+
+a.  advance the worldwide promotion of and support for the R open source language and environment as the preferred language for statistical computing and graphics (the "Environment");
+
+b.  create, organize, establish, maintain and develop infrastructure projects, technical and infrastructure collaboration initiatives, support specific initiatives related to the Environment and within the budget approved, and as provided by, the Board, and such other initiatives (collectively, "Projects") as the Infrastructure Steering Committee deems appropriate to support, enable and promote the Environment;
+
+c.  encourage and increase user adoption, involvement with, and contribution to, the Environment;
+
+d.  facilitate communication and collaboration among users and developers of the Environment, the R Consortium and the R Foundation;
+
+e.  serve as the primary point of contact among the R Consortium and its user and developer base and act as a liaison to open source communities;
+
+f.  operate within budgets approved by the Board;
+
+g.  support and maintain policies set by the Board; and
+
+h.  undertake such other activities as may from time to time be appropriate to further the purposes and achieve the goals set forth above.
+
+## 2. Membership on the Infrastructure Steering Committee
+
+The voting membership of the Infrastructure Steering Committee shall consist of:
+
+a.  one appointed representative from each Platinum Member;
+
+b.  one appointed representative from the R Foundation Member;
+
+c.  three elected representative, selected by the Silver Members as a class; and
+
+d.  the project lead from each top-level project, subject to section 3.g.
+    below.
+
+## 3. Operation of the Infrastructure Steering Committee
+
+a.  The Infrastructure Steering Committee shall elect a Chair and an ISC Director (as defined in Section 4.3(d) of the R Consortium By-laws).
+
+b.  The Chair and ISC Director may be (but are not required to be) the same person.
+
+c.  The Infrastructure Steering Committee shall be under the leadership of the Chair, with the advice and consent of the Board, who shall serve at the pleasure of the Infrastructure Steering Committee and the Board.
+
+d.  Each of the Infrastructure Steering Committee Chair and ISC Director shall be elected annually with no term limits.
+
+e.  Any collaborator, user or developer of the Environment (collectively a "Collaborator"), can suggest, submit or otherwise propose a Project for consideration by the Infrastructure Steering Committee.
+    The Infrastructure Steering Committee may implement such rules concerning format and minimum proposal requirements as it reasonably sees fit ("Proposal Requirements").
+
+f.  The Infrastructure Steering Committee may approve a process for the creation of and organization of Projects and the appointment of top-level projects as the Infrastructure Steering Committee deems necessary.
+
+g.  The Infrastructure Steering Committee may from time to time designate particular Projects as top-level projects and specify an individual as the project lead for the top-level project (who will then become a voting member of the Infrastructure Steering Committee if the project lead's employer is not otherwise represented on the Infrastructure Steering Committee, until such time as they are replaced as project lead or the Project ceases by Infrastructure Steering Committee action to be a top-level project).
+
+h.  Any Project can be concluded, archived or otherwise terminated, and any top-level project can lose its status as a top-level project, by action of the Infrastructure Steering Committee.
+
+i.  Any Project that involves code dependencies with the R language will require collaboration with the R Foundation or other maintainer of R code and permission from the relevant team.
+
+## 4. Voting
+
+a.  Actions of the Infrastructure Steering Committee can be taken by meeting at which a quorum of voting representatives is present or by written action.
+    Meetings can be held in person or via any electronic, telecommunication or other medium through which the meeting participants can clearly speak and hear each other.
+    In the case of action by meeting, a quorum shall consist of a majority of the voting representatives of the Infrastructure Steering Committee.
+
+b.  While it is the goal of the R Consortium to operate as a consensus based community, if any decision requires a vote to move forward, votes shall be based on a majority vote of the Infrastructure Steering Committee voting representatives then in attendance, or, in the case of written action, a vote of the majority of the voting members.
+    In the event of a tied vote, the Chair shall be entitled to submit a tie-breaking vote.
+
+## 5. Policy
+
+The Infrastructure Steering Committee will, to the best of its ability, adhere to the policies set forth below.
+In cases where the Infrastructure Steering Committee makes a judgment that the goals of R Consortium are better served by making exceptions to these policies, it is expected that the Infrastructure Steering Committee will communicate these exceptions and indicate their reasons to the Board at the next Board meeting.
+
+a.  The scope of projects chosen by the Infrastructure Steering Committee will focus on outreach, development and support of the user base, support of developers, support of the R Foundation, and general advancement of the Environment as defined in the R Consortium By-laws.
+    R Consortium will support projects focused on the following:
+
+    i.  The advancement of user adoption, involvement with, and contribution to, the Environment;
+
+    ii. Increasing communication and collaboration among users and developers of the Environment, the R Consortium and the R Foundation;
+
+    iii. Serving as the primary point of contact among the R Consortium and its user and developer base;
+
+    iv. Collaboration with external and industry projects;
+
+    v.  Funding of specific initiatives related to the Environment, within the parameters and budget set by the Board; and
+
+    vi. Other projects that the Infrastructure Steering Committee determines will improve the Environment.
+
+b.  To the extent possible, there should be no overlap between the significant functions of top-level projects, and top-level projects should not interfere with their respective operations, purpose or goals.
+
+c.  The following relate to the operation of the Infrastructure Steering Committee.
+
+    i.  **Communication**: All communication between and within the Infrastructure Steering Committee and projects will be in a fair, open and consistent fashion.
+
+    ii. **Openness**: The Infrastructure Steering Committee should ensure that all decisions are made in an open and transparent fashion.
+
+    iii. **Responsive to Collaborators, Users and Developers**: The Infrastructure Steering Committee should ensure issues and needs of Collaborators are being addressed in a timely fashion and that Collaborators can submit input and suggestions to the Infrastructure Steering Committee.
+
+## 6. Amendments
+
+a.  This charter may be amended by action of the Board of Directors of the R Consortium.
+
+## 7. Intellectual Property Policy
+
+a.  In the case of all Projects involving the deriving or generation of code or documentation, the commitment and contribution of such code or documentation shall comply with, and be under, any applicable licensing requirements (outbound and inbound), and where no such licensing requirements exist, the commitment and contribution of such code or documentation shall be done under a license and pursuant to such other requirements, such as the submission of a developer's certificate of origin, as may be approved by the Infrastructure Steering Committee. As part of the approval process of any license by the Infrastructure Steering Committee pursuant to this Section 7, the Infrastructure Steering Committee shall notify the Board of its intended license selection and provide the Board with an opportunity to comment on such license selection.

--- a/governance/isc-charter.md
+++ b/governance/isc-charter.md
@@ -1,6 +1,6 @@
 ---
 title: "R Consortium Infrastructure Steering Committee Charter"
-date: 2023-08-11
+date: 2024-08-13
 number-sections: false
 ---
 
@@ -34,7 +34,9 @@ a.  one appointed representative from each Platinum Member;
 
 b.  one appointed representative from the R Foundation Member;
 
-c.  three elected representative, selected by the Silver Members as a class; and
+c.  a number of elected representative, selected by the Silver Members as a class
+    that is equal to the number in the R Consortium Board of Directors elected
+    Silver Representative; and
 
 d.  the project lead from each top-level project, subject to section 3.g.
     below.


### PR DESCRIPTION
This PR replaces the PDF version of the ISC Charter with a Markdown version, which is rendered in HTML by Quarto.

Members of the ISC team have:

1. converted the 2023-08-11 version of the ISC Charter to Markdown (two people took different approaches and got the same results)
2. they then repeated this for the 2024-08-13 version.

The nice thing with maintaining the Charter in plain text (here Markdown) is that it is straightforward to track changes, e.g. https://github.com/RConsortium/rconsortium_website/commit/5e77041a94757087660509ffa939d798c7c03ab4. Doing the same with PDFs is much harder.  This will also allow us to automatically spellcheck the Charter (just like we could for the rest of the website).  With Markdown, we also avoid any formatting issues. A Markdown/HTML version is more accessible than a PDF.

PS. I think we should move our other RC PDF documents into Markdown as well.  We could probably still render also PDF versions, but I don't think it's really necessary.
