### PR TITLE
updated github workflow to R 4.5.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install R
         uses: r-lib/actions/setup-r@v2
         with:
-          r-version: '4.2.0'
+          r-version: '4.5.0'
 
       - name: Set up Renv
         uses: r-lib/actions/setup-renv@v2


### PR DESCRIPTION
if it fails, try R 4.4.
The original R was 4.2.
We can't install some updated packages using R 4.2
The version of R is specified in the `.github/publish.yaml` instructions