### PR TITLE
Alias old blogs

### DIFF
--- a/posts/free-boba-tea-and-technical-r-topics-lure-young-learners-to-new-brunei-r-user-group/index.qmd
+++ b/posts/free-boba-tea-and-technical-r-topics-lure-young-learners-to-new-brunei-r-user-group/index.qmd
@@ -32,11 +32,11 @@ and strategy, and ensure that its initiatives align with its mission of promotin
 programming and fostering a supportive learning environment, focusing on community 
 engagement and collaboration.
 
-![](smiles.jpg)
+![](smiles.jpg){fig-alt="Brunei R User Group members"}
 
 **Can you share what the R community is like in Brunei? **
 
-![](brunei-rugs-logo.png){width=50%}
+![](brunei-rugs-logo.png){width=50% fig-alt="Brunei R users group logo"}
 
 The R community in Brunei may be small, but it is growing thanks to the efforts of 
 the Brunei R User Group. The group organizes monthly meetups and events to promote 
@@ -53,7 +53,7 @@ local R community.
 **You hosted a Meetup, “[R>aya with R](https://www.meetup.com/bruneir/events/300000854/?eventOrigin=group_events_list),” 
 in April. Can you share more about the topic? Why this topic? **
 
-![](brunei-raya-meetup.jpg)
+![](brunei-raya-meetup.jpg){fig-alt="Brunei R User Group Raya Meetup"}
 
 The R User Group’s “[R>aya with R](https://bruneir.github.io/posts/bru-2/)” Meetup in 
 Brunei was a lively event that combined Hari Raya Aidilfitri’s (Eid-ul-Fitr) festive 
@@ -61,7 +61,7 @@ spirit with the exploration of R programming. To engage younger audiences, we of
 free boba tea as a beverage during the session. The event featured informative sessions 
 led by expert community members, each focusing on advanced topics relevant to different fields.
 
-![](boba.jpg)
+![](boba.jpg){fig-alt="Boba tea at Brunei R Users Group Meetup}
 
 One of the critical presentations was on “Survival Analysis” 
 by [Dr. Elvynna Leong](https://www.linkedin.com/in/elvynna-leong-84b449190/?originalSubdomain=bn). She 
@@ -69,7 +69,7 @@ explained statistical techniques to predict the time until an event of interest,
 guests’ arrival at a Hari Raya open house. This topic is directly related to fields 
 that depend on time-to-event data, such as healthcare or actuarial science.
 
-![](presentation.jpg)
+![](presentation.jpg){fig-alt="presentation Survival Analysis by Dr. Elvynna Leong"}
 
 One of the highlights was [Wafid Sophian](https://www.linkedin.com/in/wafid-sophian-6b8073141/?originalSubdomain=bn)’s session 
 on “Simulation Methods for Economic Analysis.” In this presentation, Wafid demonstrated how R can be 

--- a/posts/free-boba-tea-and-technical-r-topics-lure-young-learners-to-new-brunei-r-user-group/index.qmd
+++ b/posts/free-boba-tea-and-technical-r-topics-lure-young-learners-to-new-brunei-r-user-group/index.qmd
@@ -1,8 +1,11 @@
 ---
 title: "Free Boba Tea and Technical R Topics Lure Young Learners to New Brunei R User Group"
+aliases: 
+  - "/blog/2024/09/20/free-boba-tea-and-technical-r-topics-lure-young-learners-to-new-brunei-r-user-group"
 description: "The R community in Brunei may be small, but it is growing thanks to the efforts of the Brunei R User Group."
 author: "R Consortium"
 image: "smiles.jpg"
+image-alt: "Brunei R User Group Meeting"
 date: "09/20/2024"
 ---
 
@@ -14,7 +17,8 @@ monthly meetups and events to advance R skills across various sectors in Brunei.
 Through these efforts, Haziq aims to build a supportive and inclusive R community, 
 encouraging both personal growth and data-driven innovation in the region.
 
-![](haziq-jamil.jpg)
+![](haziq-jamil.jpg){fig-alt="Haziq Jamil Assistant Professor in Statistics at Universiti 
+Brunei Darussalam"}
 
 **Please share your background and involvement with the RUGS group.**
 

--- a/posts/free-boba-tea-and-technical-r-topics-lure-young-learners-to-new-brunei-r-user-group/index.qmd
+++ b/posts/free-boba-tea-and-technical-r-topics-lure-young-learners-to-new-brunei-r-user-group/index.qmd
@@ -55,13 +55,14 @@ in April. Can you share more about the topic? Why this topic? **
 
 ![](brunei-raya-meetup.jpg){fig-alt="Brunei R User Group Raya Meetup"}
 
-The R User Group’s “[R>aya with R](https://bruneir.github.io/posts/bru-2/)” Meetup in 
+The R User Group’s "[R>aya with R](https://bruneir.github.io/posts/bru-2/)" Meetup in 
 Brunei was a lively event that combined Hari Raya Aidilfitri’s (Eid-ul-Fitr) festive 
 spirit with the exploration of R programming. To engage younger audiences, we offered 
 free boba tea as a beverage during the session. The event featured informative sessions 
 led by expert community members, each focusing on advanced topics relevant to different fields.
 
-![](boba.jpg){fig-alt="Boba tea at Brunei R Users Group Meetup}
+![](boba.jpg){fig-alt="Brunei R User Group Boba Tea"}
+
 
 One of the critical presentations was on “Survival Analysis” 
 by [Dr. Elvynna Leong](https://www.linkedin.com/in/elvynna-leong-84b449190/?originalSubdomain=bn). She 


### PR DESCRIPTION
Set up alias for the path of this old blog post:

https://archive.r-consortium.org/blog/2024/09/20/free-boba-tea-and-technical-r-topics-lure-young-learners-to-new-brunei-r-user-group

also

* set up alt text for image for thumbnail
* set up alt text for images in body of blog post