### PR TITLE
Fix incorrect link to rainbowR in blog post

### DIFF
--- a/posts/rainbow-r-inclusive-space-LGBTQ-coders/index.qmd
+++ b/posts/rainbow-r-inclusive-space-LGBTQ-coders/index.qmd
@@ -43,6 +43,6 @@ Looking ahead, Ella's fellowship with the Software Sustainability Institute will
 
 ## A Call to Action
 
-Whether you're a member of the LGBTQ+ community or an ally, rainbowR welcomes you to get involved. By joining, you gain access to a vibrant network of R enthusiasts, opportunities for collaboration, and a platform to promote LGBTQ+ issues within the R community. To learn more or join the community, visit [rainbow.org](https://rainbow.org).
+Whether you're a member of the LGBTQ+ community or an ally, rainbowR welcomes you to get involved. By joining, you gain access to a vibrant network of R enthusiasts, opportunities for collaboration, and a platform to promote LGBTQ+ issues within the R community. To learn more or join the community, visit [rainbowr.org](https://rainbowr.org).
 
 In conclusion, rainbowR embodies the belief that a diverse and inclusive community enriches the R ecosystem. By fostering connections, supporting members, and promoting awareness, rainbowR continues to make a positive impact on the R community and beyond. We invite you to be a part of this transformative journey.


### PR DESCRIPTION
The post incorrectly linked to rainbow.org instead of rainbowr.org.