### PR TITLE
Add accessible alt text to blog posts and webinars (batch 1)

### DIFF
--- a/media-partners.qmd
+++ b/media-partners.qmd
@@ -4,6 +4,6 @@ The R Consortium is proud to partner with the following media and associations t
 about R community activities around the globe. If you are interested in becoming a media partner, 
 please contact us at info@r-consortium.org.
 
-![](images/r-bloggers-logo.png)
+![](images/r-bloggers-logo.png){fig-alt="r bloggers logo"}
 
 R news and tutorials contributed by hundreds of R bloggers

--- a/posts/2025-in-review-growth-community-momentum/index.qmd
+++ b/posts/2025-in-review-growth-community-momentum/index.qmd
@@ -14,7 +14,7 @@ As we close out 2025, I want to pause and reflect on what has been an energizing
 
 We started the year with [a refined mission](https://r-consortium.org/about/) and renewed energy. Throughout the year, the R Consortium worked to support and share the community’s efforts across the world from dozens of community organizers, and a wide range of industries – from healthcare and finance to environmental science, journalism, and public policy.
 
-![](r-consortium-mosaic.png)
+![](r-consortium-mosaic.png){fig-alt="r consortium mosaic"}
 
 ## Bringing the Community Together
 

--- a/posts/Full-time-Korea-R-User-Group-Founder-Victor-Lee-Sees-AI-Future-for-R-and-Quarto-Textbooks-R-Consortium/index.qmd
+++ b/posts/Full-time-Korea-R-User-Group-Founder-Victor-Lee-Sees-AI-Future-for-R-and-Quarto-Textbooks-R-Consortium/index.qmd
@@ -11,7 +11,7 @@ image-alt: "Full-time Korea R User Group Founder Victor Lee Sees AI Future for R
 
 ---
 
-![](victor.png)
+![](victor.png){fig-alt="Full-time Korea R User Group Founder Victor Lee Sees AI Future for R and Quarto Textbooks"}
 
 The R Consortium recently interviewed Victor Lee, organizer of the [Korea R User Group](https://r2bit.com/), about his role establishing and expanding the Korean R community. Victor shared his journey, beginning with an introduction to R and open source programming languages while working at the Hyundai Motor Company, and later, his efforts in establishing the tidyverse community in Korea. He highlighted his extensive experience with R, including writing blog posts, publishing Quarto books, and building websites for the Korea R User Group. Victor will be a Software Carpentry instructor at the Software Carpentry Workshops at Sejong University. 
 
@@ -42,7 +42,7 @@ R has evolved from a simple data analysis and statistical language to a tool tha
 
 **Why do industry professionals come to your user group? What is the benefit for attending?**
 
-![](krusergroup.jpg)
+![](krusergroup.jpg){fig-alt="krusergroup"}
 
 In Korea, about 20 to 30 years ago, R was the number one programming language for data science and statistics, particularly in areas like machine learning. However, with the rise of Python, many R users transitioned to Python due to its increasing popularity. Despite this shift, R remains significant in Korea, with many people continuing to use both R and Python.
 

--- a/posts/Tackling-Hurdles-Embracing-Open-Source-Packages-in-Pharmaceutical-Research/index.qmd
+++ b/posts/Tackling-Hurdles-Embracing-Open-Source-Packages-in-Pharmaceutical-Research/index.qmd
@@ -10,7 +10,7 @@ image: "R Validation Mini-Series Part 2.png"
 image-alt: "Tackling Hurdles: Embracing Open Source Packages in Pharmaceutical Research"
 
 ---
-![](R Validation Mini-Series Part 2.png)
+![](R Validation Mini-Series Part 2.png){fig-alt="R Validation Mini Series Part 2 — Tackling Hurdles: Embracing Open Source Packages in Pharmaceutical Res"}
 
 The R Validation Hub next meeting is May 21st, 12:00 PM EST. 
 

--- a/posts/a-first-for-pakistan-karachi-r-user-group-builds-r-ecosstem-from-scratch/index.qmd
+++ b/posts/a-first-for-pakistan-karachi-r-user-group-builds-r-ecosstem-from-scratch/index.qmd
@@ -6,19 +6,19 @@ description: "Muhammad Uzair Aslam, founder of the Karachi R User Group, spoke w
 author: "R Consortium"
 categories: ["rugs", "software development", "asia"]
 image: "KarachiRUGlogo.png"
-image-alt: "picture of Karachi R User Group logo"
+image-alt: "Karachi R User Group logo"
 date: "12/04/2025"
 ---
 
 [Muhammad Uzair Aslam](https://www.linkedin.com/in/uzairdatascientist/), founder of the [Karachi R User Group](https://www.meetup.com/karachi-r-user-group/), spoke with the R Consortium about growing an open and volunteer-led R community in Pakistan—one of the first of its kind in the country. Since starting the group in 2023, Uzair has focused on building trust, increasing awareness of R, and creating accessible events for learners across cities. The R Consortium [spoke with Uzair about the Karachi R User Group’s work with R for Public Health Data Analysis previously](https://r-consortium.org/posts/r-for-public-health-data-analysis-in-karachi-pakistan/index.html). This time, Uzair is sharing how the group has evolved from informal online meetups to hosting international speakers and publishing sessions on YouTube. He also discussed the community’s rising interest in tools like Quarto and ggplot2, recent consulting work in industrial forecasting using R, and the ongoing challenge of encouraging more local contributions.
 
-![](UzairAslam.png){width=30%}
+![](UzairAslam.png){fig-alt="A First for Pakistan: Karachi R User Group Builds R Ecosystem from Scratch" width=30%}
 
 ## Please update us on how the group has been doing since we last spoke and share your experience.
 
 Since we last spoke, our user group has made significant strides in growth and community engagement. We started this initiative in 2023 with just 10 to 15 members. During that first year, our focus was on building the foundation—introducing the concept of an open, volunteer-led R community in Pakistan, which was the first of its kind in the country. One of our key challenges early on was gaining trust and clarifying that these events are completely free and community-driven, with no commercial backing.
 
-![](KarachiRUGlogo.png)
+![](KarachiRUGlogo.png){fig-alt="KarachiRUG logo"}
 
 In 2024, we began organising more frequent and structured events, which led to a noticeable increase in interest and participation. Our commitment to consistency and open learning helped establish our reputation, and we gradually grew to a community of over 500 members—a major milestone for us.
 
@@ -44,7 +44,7 @@ To improve engagement, I’ve been leveraging multiple social media platforms, i
 
 ## You hosted a Meetup titled “[Reporting Champions Trophy Data using Quarto and R](https://www.youtube.com/watch?v=vIrSy5AXrz0),” can you share more on the topic covered? Why this topic?
 
-![](ChampionsTrophyDatausingR.png)
+![](ChampionsTrophyDatausingR.png){fig-alt="Champions Trophy Data using R"}
 
 We recently hosted an engaging talk on our Meetup group by [Dr. Zahid Asghar](https://www.linkedin.com/in/zahid-asghar/) from Islamabad University titled “Reporting Champions Trophy Data using Quarto and R.” The session introduced the community to Quarto as a modern tool for creating parameterised, automated, and visually rich reports. Using real-world data from the ESPN Cricinfo API, Dr. Zahid demonstrated how to generate customised player statistics reports—blending R’s data manipulation capabilities with Quarto’s dynamic reporting features. This topic was chosen to help data professionals move beyond static dashboards and adopt reproducible, scalable reporting workflows, and it was well-received by attendees for its practical relevance and clarity.
 

--- a/posts/a-new-r-community-in-ahmedabad/index.qmd
+++ b/posts/a-new-r-community-in-ahmedabad/index.qmd
@@ -7,7 +7,7 @@ date: "08/12/2024"
 url: "https://r-consortium.org/posts/a-new-r-community-in-ahmedabad/"
 unpublished: false
 categories: ["submissions", "pharma", "rugs", "events", "asia"]
-image-alt: "A New R Community in Ahmedabad, India, focused on Clinical Research and Pharmaceutical Industries"
+image-alt: "Ahmedabad R User Group organizer Sanket Sinojia"
 
 ---
 
@@ -15,7 +15,7 @@ The R Consortium recently interviewed [Sanket Sinojia](https://www.linkedin.com/
 
 Since its official setup in 2023, ARUG has rapidly grown into a vibrant group with over 100 active members. The community fosters collaboration, knowledge-sharing, and mentorship, contributing significantly to the broader R ecosystem. Sanket’s dedication to data science and community building is evident in his efforts to organize impactful events, mentor new members, and drive the group’s growth.
 
-![](unnamed.png)
+![](unnamed.png){fig-alt="Ahmedabad R User Group community members"}
 
 **Please share about your background and involvement with the RUGS group.**
 
@@ -23,7 +23,7 @@ I’ve been working in statistical programming and data sciences in the clinical
 
 While the group was initially formed in 2021, its formal setup was completed in 2023 with collaboration from the R Consortium. Since then, I’ve been organizing events, facilitating discussions, and contributing to the group’s growth. My passion for data science and community building drives my commitment to ARUG. Beyond organizing, I also mentor new members, helping them navigate the complexities of R. It’s incredibly rewarding to see the community thrive and to witness the impact of our collective efforts on advancing the field. ARUG is the first city-based group in India associated with R Consortium and the only R user group focused on Clinical Research & Pharmaceutical Industries.
 
-![](unnamed2.png)
+![](unnamed2.png){fig-alt="Ahmedabad R User Group members at a meetup"}
 
 **Can you share what the R community is like in Ahmedabad?** 
 
@@ -31,7 +31,7 @@ Ahmedabad, a world heritage city known for its rich history and vibrant culture,
 
 **You had a** [**meetup on July 21st, 2024**](https://www.meetup.com/ahmedabad-r-users-group/events/302239112/)**. Can you share more about the topic covered? Why this topic?**
 
-![](unnamed3.png)
+![](unnamed3.png){fig-alt="Ahmedabad R User Group R Evolution clinical trials meetup July 2024"}
 
 The meetup was a highly anticipated event entitled ‘R Evolution: Shaping the Future of Clinical Trials.’ We chose this topic because it aligns perfectly with the emerging demand for R in our industry and aims to make our attendees aware of the transformative potential R brings to clinical research. Here’s a quick recap:
 
@@ -55,15 +55,15 @@ The ARUG Event Team – [Ankit Vadodariya](http://linkedin.com/in/ankit-vadodari
 
 **Who was the target audience for attending this event?** 
 
-![](unnamed4.png)
+![](unnamed4.png){fig-alt="Clinical and pharmaceutical industry professionals at Ahmedabad R User Group event"}
 
 Our target audience primarily includes professionals and researchers from the clinical and pharmaceutical industries. This encompasses data scientists, statistical programmers, biostatisticians, clinical trial analysts, and anyone interested in leveraging R for data analysis and visualization in these fields. We also welcome newcomers who are eager to learn and contribute to this dynamic industry. By targeting this specific audience, we ensure our content is highly relevant and impactful, addressing real-world challenges and opportunities our members face. Additionally, our events offer networking opportunities that can lead to collaborations.
 
 **Any techniques you recommend using for planning for or during the event? (Github, zoom, other) Can these techniques be used to make your group more inclusive to people that are unable to attend physical events in the future?**   
 
-![](unnamed5.png)
+![](unnamed5.png){fig-alt="Ahmedabad R User Group event planning and collaboration"}
 
-![](unnamed6.png)
+![](unnamed6.png){fig-alt="Ahmedabad R User Group virtual session or hybrid event"}
 
 For planning and executing our events, we rely on a combination of tools such as [GitHub](https://github.com/ssinojia/ARUG/tree/main) for collaborative project management and repositories, Zoom for virtual sessions, and [Meetup](https://www.meetup.com/ahmedabad-r-users-group/) and [LinkedIn ARUG](https://www.linkedin.com/company/arug/about/) pages for continuous engagement and communication. These tools not only streamline our processes but also enhance accessibility. By utilizing these technologies, we can include members who cannot attend physical events, making our group more inclusive. We share our event summaries and slides on GitHub, ensuring that valuable information is accessible to all members. Additionally, we are considering recording sessions and sharing them on platforms like YouTube to further extend the reach of our events. Using these tools also allows us to gather feedback and improve future events, ensuring we meet the evolving needs of our community. This approach helps us maintain a vibrant and connected community, regardless of geographical limitations.
 

--- a/posts/aligning-belief-and-profession-using-r-in-protecting-the-penobscot-nation-traditional-lifeways-r-consortium/index.qmd
+++ b/posts/aligning-belief-and-profession-using-r-in-protecting-the-penobscot-nation-traditional-lifeways-r-consortium/index.qmd
@@ -3,6 +3,7 @@ title: "Aligning Beliefs and Profession: Using R in Protecting the Penobscot Nat
 description: "Angie Reed sampling Chlorophyll on the Penobscot River where a dam was removed In a recent interview by the R Consortium, Angie Reed, Water Resources Planner for the Penobscot Indian…"
 author: "R Consortium"
 image: "angie.png"
+image-alt: "Aligning Beliefs and Profession: Using R in Protecting the Penobscot Nation’s Traditional Lifeways"
 date: "03/27/2024"
 format:
   html:
@@ -54,7 +55,7 @@ My co-worker, Jan Paul, and I had the pleasure of attending and [presenting ](ht
 
 
 
-![](water-map.png)
+![](water-map.png){fig-alt="water map"}
 
 
 I find that people connect more with maps, especially when it comes to visualizing data that is geographically referenced. For instance, if there’s an issue in the water, people can see exactly where it is on the map. This is particularly relevant as people in this area are very familiar with the Penobscot River watershed.  My aim is to create tools that are not only interactive but also intuitive, allowing users to zoom into familiar areas and understand what’s happening there. 
@@ -96,7 +97,7 @@ I am deeply committed to engaging the younger generation, especially the student
 
 
 
-![](sampling-bacteria.png)
+![](sampling-bacteria.png){fig-alt="sampling bacteria"}
 <div style="text-align: center;">
   <p>Sampling for Bacteria</p>
 </div>
@@ -111,7 +112,7 @@ Beyond the Penobscot Nation school, we’re extending our reach to local high sc
 
 
 
-![](processing-bacteria.png)
+![](processing-bacteria.png){fig-alt="processing bacteria"}
 <div style="text-align: center;">
   <p>Processing bacteria sample</p>
 </div>

--- a/posts/announcing-health-technology-assessment-HTA-working-group/index.qmd
+++ b/posts/announcing-health-technology-assessment-HTA-working-group/index.qmd
@@ -3,6 +3,7 @@ title: "Announcing the Health Technology Assessment (HTA) Working Group"
 description: "The HTA WG has a mission of promoting the use of R in all aspects of HTA analytics, including both clinical assessment and economic evaluation."
 author: "R Consortium"
 image: "hta-main-page.png"
+image-alt: "Announcing the Health Technology Assessment (HTA) Working Group"
 date: "10/01/2024"
 url: "https://r-consortium.org/posts/announcing-health-technology-assessment-HTA-working-group/"
 unpublished: false

--- a/posts/applied-epidemiology-in-r-cape-town-r-user-groups-contribution-to-global-immunization/index.qmd
+++ b/posts/applied-epidemiology-in-r-cape-town-r-user-groups-contribution-to-global-immunization/index.qmd
@@ -13,7 +13,7 @@ date: "01/07/2026"
 
  [Jared Norman](https://www.linkedin.com/in/jared-norman-71b4b6187/) and [Retselisitsoe Monyake](https://www.linkedin.com/in/rmonyake/), organizers of the [Cape Town R User Group](https://www.meetup.com/cape-town-r-user-group/), recently spoke with the R Consortium about strengthening South Africa’s R community and advancing infectious disease modeling at the Modeling and Simulation Hub Africa (MASHA), which is part of the Department of Statistics at the University of Cape Town (UCT). Alongside efforts to organize local meetups and collaborate with Johannesburg, they shared their work on DTPBoost—an R-based tool developed in collaboration with the CDC and AFENET to help countries evaluate and optimize DTP booster vaccination strategies. In this interview, they discuss how community building, Shiny development, and applied epidemiological modeling come together to strengthen R’s impact in global health.
  
- ![](CapetownRUGOrganizers.png)
+ ![](CapetownRUGOrganizers.png){fig-alt="Capetown RUG Organizers"}
 
 ## Please share about your background and involvement with the RUGS group.
 
@@ -39,7 +39,7 @@ In terms of networking, I engage with a lot of people in the R community, includ
 
 Additionally, we have PhD students at our hub to whom we give workshops. I’ve conducted some R workshops, including one in Kigali, Rwanda, where I taught participants how to use Shiny, and I believe it went quite well.
 
-![](CapetownRUGMeetup.png)
+![](CapetownRUGMeetup.png){fig-alt="Capetown RUG Meetup"}
 
 ## Can you share what the R community is like in South Africa?
 

--- a/posts/apply-now-r-consortium-infrastructure-steering-committee/index.qmd
+++ b/posts/apply-now-r-consortium-infrastructure-steering-committee/index.qmd
@@ -11,7 +11,7 @@ image-alt: "Apply Now! R Consortium Infrastructure Steering Committee (ISC) Gran
 
 ---
 
-![](R CONSORTIUM Q7 2023 NEWSLETTER.jpg)
+![](R CONSORTIUM Q7 2023 NEWSLETTER.jpg){fig-alt="Apply Now! R Consortium Infrastructure Steering Committee (ISC) Grant"}
 a
 Help build R infrastructure! We’re opening the call for proposals for the 2024 Infrastructure Steering Committee (ISC) Grant Program. The R Consortium is dedicated to enriching the R Ecosystem, directly supporting projects that strengthen both its technical and social infrastructures.
 

--- a/posts/books-beginners-big-ideas-beatriz-milz-fostering-r-ladies-sao-paulo-community/index.qmd
+++ b/posts/books-beginners-big-ideas-beatriz-milz-fostering-r-ladies-sao-paulo-community/index.qmd
@@ -3,6 +3,7 @@ title: "Books, Beginners, and Big Ideas: Beatriz Milz on Fostering R-Ladies São
 description: "Beatriz Milz, a co-organizer of R-Ladies São Paulo, recently spoke with the R Consortium about the vibrant growth of the R community in São Paulo and its commitment to inclusivity and accessible learning."
 author: "R Consortium"
 image: "R-LadiesSaoPaulo.png"
+image-alt: "Books, Beginners, and Big Ideas: Beatriz Milz on Fostering R-Ladies São Paulo’s Vibrant Community"
 date: "12/23/2024"
 url: "https://r-consortium.org/posts/books-beginners-big-ideas-beatriz-milz-fostering-r-ladies-sao-paulo-community/"
 unpublished: false
@@ -13,7 +14,7 @@ image-alt: "Books, Beginners, and Big Ideas: Beatriz Milz on Fostering R-Ladies 
 
 [Beatriz Milz](https://beamilz.com/about), a co-organizer of [R-Ladies São Paulo](https://www.meetup.com/rladies-sao-paulo/?eventOrigin=event_home_page), recently spoke with the R Consortium about the vibrant growth of the R community in São Paulo and its commitment to inclusivity and accessible learning. Beatriz shared insights into the group’s activities, from organizing popular in-person and online events to coordinating a book club focused on the newly translated R for Data Science in Portuguese. She also discussed the unique needs of R users in Brazil and how R-Ladies São Paulo supports beginners and advanced users through collaborative events and community-driven resources.
 
-![](BeatrizMilz.jpg)
+![](BeatrizMilz.jpg){fig-alt="Beatriz Milz R-Ladies São Paulo"}
 
 
 
@@ -43,7 +44,7 @@ We also have many members with a background in Statistics. Since most university
 
 It varies. This year, we hosted two in-person and many more online events—11. We held an average of 6.5 events per year. However, this year, we focused more on online events and had fewer in-person ones, mostly because booking venues for in-person events has been more difficult.
 
-![](R-LadiesSaoPauloEvents.png)
+![](R-LadiesSaoPauloEvents.png){fig-alt="R Ladies São Paulo Events"}
 
 **Regarding your experience, are people more interested in online or in-person events?**
 
@@ -57,7 +58,7 @@ While online events can have a broader impact on reaching a larger audience, in-
 
 **Please provide us with an update on your group's recent activities.**
 
-![](R-LadiesSaoPaulo.png)
+![](R-LadiesSaoPaulo.png){fig-alt="R Ladies São Paulo"}
 
 I wanted to discuss a series of events related to the book club we’re hosting. In Brazil, we speak Brazilian Portuguese. An editorial group published the highly regarded book [R for Data Science](https://r4ds.hadley.nz/) in Portuguese. The first edition is available only through purchase, but the English version is free online.
 

--- a/posts/brewing-success-with-rum-how-inclusivity-fuels-manchesters-thriving-r-community/index.qmd
+++ b/posts/brewing-success-with-rum-how-inclusivity-fuels-manchesters-thriving-r-community/index.qmd
@@ -6,7 +6,7 @@ author: "R Consortium"
 format: html
 editor: visual
 image: "rum-main-image.png"
-image-alt: Organizers of the R User Group at the University of Manchester
+image-alt: "Organizers of the R User Group at the University of Manchester"
 date: "06/09/2025"
 url: "https://r-consortium.org/posts/brewing-success-with-rum-how-inclusivity-fuels-manchesters-thriving-r-community/"
 unpublished: false

--- a/posts/bridging-gaps-and-breaking-barriers-a-year-of-r-innovation-with-the-china-pharmarug/index.qmd
+++ b/posts/bridging-gaps-and-breaking-barriers-a-year-of-r-innovation-with-the-china-pharmarug/index.qmd
@@ -8,6 +8,7 @@ author:
   - name: "Yanli Chang, Johnson & Johnson"
 categories: ["asia", "pharma", "events"]
 image: "third-pharmarug-conf.png"
+image-alt: "Bridging Gaps and Breaking Barriers: A Year of R Innovation with the China PharmaRUG"
 date: "12/11/2025"
 image-alt: "Bridging Gaps and Breaking Barriers: A Year of R Innovation with the China PharmaRUG"
 
@@ -17,7 +18,7 @@ The use of R in the pharmaceutical industry has shifted from exploratory researc
 
 Here are three pivotal moments from the China PharmaRUG in 2025 that showcased technical innovation and strategic foresight.
 
-![](third-pharmarug-conf.png)
+![](third-pharmarug-conf.png){fig-alt="Third Pharmarug Conf"}
 
 ## 1. The 3rd PharmaRUG Conference: Innovation in Hybrid Format (March 2025)
 
@@ -33,7 +34,7 @@ This meeting went beyond standard presentations and focused on overcoming techni
 
 The diversity of topics—ranging from AI-generated ADaM datasets to easeP21 for validation—demonstrated that the local community is not just adopting R, but actively pushing the boundaries of what the language can do in a regulated environment.
 
-![](apac-track.png)
+![](apac-track.png){fig-alt="apac track — Bridging Gaps and Breaking Barriers: A Year of R Innovation with the China PharmaRUG"}
 
 ## 2. Global Connection: R in Pharma APAC Track (November 2025)
 
@@ -41,7 +42,7 @@ In November, the PharmaRUG played a crucial role in the R/Pharma 2025 conference
 
 The Shanghai gathering, hosted at the Johnson & Johnson office, served as a physical anchor for the virtual track. This event featured keynotes and over 18 regular presentations covering reporting, prediction, and AI. It was a testament to the "multiverse" concept often discussed in the industry—where end-to-end clinical reporting moves away from legacy systems toward a diverse ecosystem of open-source tools. By aligning with the global R/Pharma schedule, the China PharmaRUG ensured that local innovations were shared on a global stage, reinforcing the R Consortium’s mission to foster international collaboration.
 
-![](dec-4-gathering.png)
+![](dec-4-gathering.png){fig-alt="Dec 4 gathering — Bridging Gaps and Breaking Barriers: A Year of R Innovation with the China PharmaRUG"}
 
 ## 3. Strategic Foundations: The December 4th Gathering
 

--- a/posts/bridging-gaps-tunis-r-user-groups-journey-in-democratizing-r-in-bioinformatics/index.qmd
+++ b/posts/bridging-gaps-tunis-r-user-groups-journey-in-democratizing-r-in-bioinformatics/index.qmd
@@ -43,7 +43,7 @@ Our community is a friendly, inclusive, and welcoming space for anyone passionat
 
 Hedia: In Tunisia, programming is mainly used in the industry, but it is not widely taught in the curriculum for biologists. This creates a gap between what is taught in the academic courses and what is required in the industry. As a result, individuals are expected to possess programming skills when they work in the industry. Still, they may not have been able to learn programming during their academic courses. This gap must be addressed to better prepare individuals for the job market.
 
-![](TunisRUser_Logo.jpeg)
+![](TunisRUser_Logo.jpeg){fig-alt="Tunis R User Logo"}
 
 **Can you please update us about the group’s recent activities?**
 

--- a/posts/bridging-the-digital-divide-umar-isah-adam-on-expanding-r-access-for-kano-nigeria-students/index.qmd
+++ b/posts/bridging-the-digital-divide-umar-isah-adam-on-expanding-r-access-for-kano-nigeria-students/index.qmd
@@ -3,6 +3,7 @@ title: "Bridging the Digital Divide: Umar Isah Adam on Expanding R Access for Ka
 description: "Umar Isah Adam, the founder and organizer of the R User Group Kano, Nigeria, spoke with the R Consortium during the pandemic about his efforts to engage the next generation of students in the R community."
 author: "R Consortium"
 image: "unnamed.jpg"
+image-alt: "Bridging the Digital Divide: Umar Isah Adam on Expanding R Access for Kano, Nigeria Students"
 date: "06/17/2024"
 url: "https://r-consortium.org/posts/bridging-the-digital-divide-umar-isah-adam-on-expanding-r-access-for-kano-nigeria-students/"
 unpublished: false

--- a/posts/bridging-the-real-time-gap-how-inwt-is-bringing-apache-kafka-to-the-r-ecosystem/index.qmd
+++ b/posts/bridging-the-real-time-gap-how-inwt-is-bringing-apache-kafka-to-the-r-ecosystem/index.qmd
@@ -3,6 +3,7 @@ title: "Bridging the Real-Time Gap: How INWT is Bringing Apache Kafka to the R E
 description: "In a recent interview with the R Consortium, Andreas Neudecker, solution architect at INWT, a data and analytics company located in Berlin, Germany, shared insights into the motivation behind developing an Apache Kafka client for R and the challenges it aims to address within the R ecosystem."
 author: "R Consortium"
 image: "Andreas.png"
+image-alt: "Bridging the Real-Time Gap: How INWT is Bringing Apache Kafka to the R Ecosystem"
 date: "11/12/2024"
 url: "https://r-consortium.org/posts/bridging-the-real-time-gap-how-inwt-is-bringing-apache-kafka-to-the-r-ecosystem/"
 unpublished: false

--- a/posts/bringing-students-researchers-and-industry-together-with-r-in-malaysia/index.qmd
+++ b/posts/bringing-students-researchers-and-industry-together-with-r-in-malaysia/index.qmd
@@ -12,7 +12,7 @@ date: "02/05/2026"
 
 [Richie Yu Yong Poh](https://www.linkedin.com/in/yong-poh-yu/?originalSubdomain=my), organizer of the [Malaysia R User Group](https://www.meetup.com/malaysia-r-user-group/), recently spoke with the R Consortium about building a national R community centered around its annual conference. He shared that the group has evolved from a small network into a robust platform that connects students, researchers, and industry practitioners through workshops, seminars, and a flagship two-day event. Richie discussed the logistics of the annual conference, the design of hands-on workshops, and R's role in bridging the gap between academia and industry through real-world applications.
 
-![](YuYongPoh.png){width=50%}
+![](YuYongPoh.png){fig-alt="YuYongPoh — Bringing Students, Researchers, and Industry Together with R in Malaysia" width=50%}
 
 **Please share about your background and involvement with the RUGS group.**
 
@@ -24,7 +24,7 @@ Over time, our team explored both R and Python, noting that they complement each
 
 The group was founded by my colleague, [Dr Poo Kuan Hoong](https://www.linkedin.com/in/kuanhoong/?originalSubdomain=my), who introduced me to the community. Given my academic background and familiarity with R, I was eager to contribute. Since those early days, the group has grown significantly. We now officially co-organize the **Annual R Conference** in partnership with my university, supplemented by periodic seminars and workshops. We also utilize social media and digital platforms to share resources, fostering a collaborative environment where members regularly exchange insights and experiences.
 
-![](MalaysiaRUGFounder.png)
+![](MalaysiaRUGFounder.png){fig-alt="MalaysiaRUG Founder"}
 
 **Let's discuss the [R conference](https://www.r-conference.com/#h.q3v7ag2doxpm) held in November. Can you provide details on the speakers, topics covered, and audience response?**
 
@@ -32,7 +32,7 @@ The R Conference in Malaysia has become a premier annual event, attracting parti
 
 The two-day format featured one day of intensive workshops followed by a day of professional talks. Due to overwhelming interest—particularly for the hands-on sessions—we moved to a larger venue to accommodate the high volume of attendees bringing their own equipment.
 
-![](R-conference-group-photo-main.png)
+![](R-conference-group-photo-main.png){fig-alt="R conference group photo"}
 
 We offered two primary workshops:
 

--- a/posts/building-bridges-in-haifa-israel/index.qmd
+++ b/posts/building-bridges-in-haifa-israel/index.qmd
@@ -3,6 +3,7 @@ title: "Building Bridges in Haifa, Israel: How the New R User Group in Haifa is 
 description: "Despite Haifa’s relatively small size, it boasts a diverse R community, including professionals from high-tech companies, academia, and startups."
 author: "R Consortium"
 image: "unnamed4.jpg"
+image-alt: "Building Bridges in Haifa, Israel: How the New R User Group in Haifa is Establishing a Diverse R Community"
 date: "08/20/2024"
 url: "https://r-consortium.org/posts/building-bridges-in-haifa-israel/"
 unpublished: false

--- a/posts/building-data-highways-kirill-mullers-journey-in-enhancing-rs-database/index.qmd
+++ b/posts/building-data-highways-kirill-mullers-journey-in-enhancing-rs-database/index.qmd
@@ -19,7 +19,7 @@ Kirill Müller is the author of the [{DBI} package](https://dbi.r-dbi.org/), whi
 -   Postgres, using the R-package RPostgres
 -   SQLite, using the R-package RSQLite
 
-![](kirill.webp){width=50%}
+![](kirill.webp){fig-alt="Kirill Müller" width=50%}
 
 > Kirill Müller is passionate about building, applying, and teaching tools for working with data and has worked on the boundary between data and computer science for more than 25 years. He has been awarded five R consortium projects over the past 8 years to improve database connectivity and performance in R and another one to investigate profiling of R and native code. Kirill is a core contributor to several tidyverse packages, including [dplyr](https://dplyr.tidyverse.org/) and [tibble](https://tibble.tidyverse.org/), and the maintainer of the [duckdb](https://r.duckdb.org/) R package. He holds a Ph.D. in Civil Engineering from ETH Zurich and is a founder and partner at [cynkra](https://www.cynkra.com/), a Zurich-based data science consultancy with a heavy focus on R. Kirill enjoys playing badminton, cycling, and hiking.
 

--- a/posts/cakes-code-and-community-reviving-the-copenhagenr-user-group/index.qmd
+++ b/posts/cakes-code-and-community-reviving-the-copenhagenr-user-group/index.qmd
@@ -3,6 +3,7 @@ title: "Cakes, Code, and Community: Rasmus Bååth’s Secret to Reviving the Co
 description: "After joining the Copenhagen R User Group in 2013, Rasmus Bååth took the lead in reviving the group in 2023 after a period of inactivity. Under his guidance, the group now focuses on industry-related topics, personal projects, and emerging tools like Quarto."
 author: "R Consortium"
 image: "copenhangenr-meetup3.png"
+image-alt: "Cakes, Code, and Community: Rasmus Bååth’s Secret to Reviving the CopenhagenR UseR Group"
 date: "10/08/2024"
 url: "https://r-consortium.org/posts/cakes-code-and-community-reviving-the-copenhagenr-user-group/"
 unpublished: false
@@ -20,7 +21,7 @@ now focuses on industry-related topics, personal projects, and emerging tools
 like Quarto. Rasmus is dedicated to fostering a vibrant local R community 
 through in-person meetups that encourage learning and collaboration.
 
-![](rasmus-baath.png)
+![](rasmus-baath.png){fig-alt="Rasmus Bååth"}
 
 The CopenhagenR UseR Group is hosting an exciting 
 “[Two Tools for Report Generation in R](https://www.meetup.com/copenhagenr-user-group/events/303309816/)” event 
@@ -53,7 +54,7 @@ years by 2023, and I felt it was a shame to let it die. I decided to restart it,
 and now we have a small but active group. We enjoy discussing industry-related 
 topics and personal projects.
 
-![](copenhangenr-meetup.png)
+![](copenhangenr-meetup.png){fig-alt="CopenhangenR meetup"}
 
 
 **Can you share what the local R community is like?**
@@ -75,7 +76,7 @@ recognize the need for in-person events. For those unable to attend, there
 is plenty of valuable content online. We don't have the setup to record events, 
 but we would consider doing so if feasible.
 
-![](copenhangenr-meetup2.png)
+![](copenhangenr-meetup2.png){fig-alt="CopenhangenR meetup2"}
 
 
 **You have a Meetup titled “[Two tools for report generation in R](https://www.meetup.com/copenhagenr-user-group/events/303309816/).” Can you share more on the topic covered? Why this topic?**
@@ -111,7 +112,7 @@ machine learning is not a common focus at our meetups, as most speakers
 are more inclined towards visualization, reporting, and statistics rather 
 than machine learning.
 
-![](copenhangenr-meetup3.png)
+![](copenhangenr-meetup3.png){fig-alt="CopenhangenR meetup3"}
 
 **Do you recommend any techniques for planning for or during the event? (GitHub, Zoom, other.) Can these techniques be used to make your group more inclusive to people who cannot attend physical events in the future?**
 

--- a/posts/clinical-reporting-roches-nest-and-admiral-teams/index.qmd
+++ b/posts/clinical-reporting-roches-nest-and-admiral-teams/index.qmd
@@ -3,6 +3,7 @@ title: "A Clinical Reporting Collaborative Triumph: Roche’s NEST and Admiral T
 description: "Details on Roche's NEST and admiral teams' open source R packages and their partnership building reusable functions and utilities, testing documentation, and more."
 author: "Joe Zhu, Leena Khatri, Emily de la Rua, Edoardo Mancini, Kangjie Zhang, Daphne Grasselly"
 image: "nest-admiral.png"
+image-alt: "A Clinical Reporting Collaborative Triumph: Roche’s NEST and Admiral Teams"
 date: "01/15/2025"
 url: "https://r-consortium.org/posts/clinical-reporting-roches-nest-and-admiral-teams/"
 unpublished: false
@@ -17,7 +18,7 @@ _Guest Post contributed by Joe Zhu, Leena Khatri, Emily de la Rua, Edoardo Manci
 
 In the dynamic world of clinical research, innovation and collaboration are key drivers of success. The NEST and admiral teams exemplify this through their groundbreaking partnership. By leveraging open-source tools and fostering a community-driven approach, they have significantly advanced data integration and reporting methodologies in the clinical research setting. This story celebrates their journey and achievements.
 
-![](nest-admiral.png)
+![](nest-admiral.png){fig-alt="Nest Admiral"}
 
 ## The NEST Team
 

--- a/posts/collaborative-growth-the-botswana-r-user-group-and-regional-partnerships/index.qmd
+++ b/posts/collaborative-growth-the-botswana-r-user-group-and-regional-partnerships/index.qmd
@@ -3,6 +3,7 @@ title: "Collaborative Growth: The Botswana R User Group and Regional Partnership
 description: "Edson Kambeu, founder and organizer of the Botswana R User Group, shares his plans to implement data into local businesses in the new growing R Community in Botswana."
 author: "R Consortium"
 image: "media.png"
+image-alt: "Collaborative Growth: The Botswana R User Group and Regional Partnerships"
 date: "05/24/2024"
 url: "https://r-consortium.org/posts/collaborative-growth-the-botswana-r-user-group-and-regional-partnerships/"
 unpublished: false

--- a/posts/community-growth-collaboration-momentum-across-r-ecosystem/index.qmd
+++ b/posts/community-growth-collaboration-momentum-across-r-ecosystem/index.qmd
@@ -6,7 +6,7 @@ description: "I have focused my efforts as executive director in building a sust
 categories: ["top level projects", "isc", "announcements", "rugs", "events"]
 author: "Terry Christiani, Executive Director"
 image: "r_wordcloud.png"
-image-alt: "word cloud of the key concepts in Terry's post"
+image-alt: "Word cloud"
 date: "03/19/2026"
 ---
 
@@ -18,7 +18,7 @@ At the R Consortium, one of our roles is to help sustain and strengthen the ecos
 
 Together, these efforts reinforce a central goal: ensuring that R remains a vibrant, collaborative environment for statistical computing, data science, and applied analytics across industries.
 
-![](2026-collage.png)
+![](2026-collage.png){fig-alt="Collage of 2026 R Consortium images"}
 
 ## Structured for the R Community
 

--- a/posts/conectaR-podcasts-and-datathons-san-carlos-r-user-group-in-costa-rica/index.qmd
+++ b/posts/conectaR-podcasts-and-datathons-san-carlos-r-user-group-in-costa-rica/index.qmd
@@ -19,7 +19,7 @@ Latin America. Additionally, Frans highlighted the challenges of building a data
 in a rural area and the creative methods they've employed to connect people through R.
 
 
-![](FransvanDunne.png)
+![](FransvanDunne.png){fig-alt="Frans van Dunne San Carlos R User Group"}
 
 
 **Please share your background and involvement with the RUGS group.**
@@ -41,7 +41,7 @@ people from Peru and other distant locations joining our group. San Carlos is a 
 with a population of around 50,000, so having individuals from different parts of Latin America 
 join us was truly amazing.
 
-![](SanCarlosRUGsmeeting.png)
+![](SanCarlosRUGsmeeting.png){fig-alt="San Carlos RUGs meeting"}
 _One of the first San Carlos R User Group meetings - February 2016, Ciudad Quesada, Costa Rica_
 
 We had to stop our online meetings because Meetup informed us that, according to their policy 
@@ -51,7 +51,7 @@ The world is different now, but that was the situation back then.
 **Can you share what the local R community is like in San Carlos? **
 
 
-![](ConectaR2019.png)
+![](ConectaR2019.png){fig-alt="ConectaR 2019"}
 _Participants of ConectaR 2019 - January 2019, San José Costa Rica_
 
 We collaborated with the University of Costa Rica to organize an event that brought together 
@@ -63,7 +63,7 @@ only confirmed that R is widely used in academia. Most statistics courses have t
 from licensed software to R. R is also used widely in industry.
 
 
-![](ConectaR2024.png)
+![](ConectaR2024.png){fig-alt="ConectaR 2024"}
 _Participants of the Tidymodels workshop during ConectaR 2024, March 2024, San José, Costa Rica_
 
 At [ixpantia](https://www.ixpantia.com/en/), the company I co-founded, we work with clients in 

--- a/posts/connecting-nebraska-through-r-jeffrey-stevens-journey-of-community-building/index.qmd
+++ b/posts/connecting-nebraska-through-r-jeffrey-stevens-journey-of-community-building/index.qmd
@@ -14,7 +14,7 @@ image-alt: "Connecting Nebraska Through R: Jeffrey Stevens’ Journey of Communi
 
  [Jeffrey Stevens](https://www.linkedin.com/in/jeffreyrstevens/), organizer of the [Nebraska R User Group](https://www.meetup.com/nebraskarusergroup/), recently spoke with the R Consortium about his efforts to establish a vibrant R community across Nebraska. Jeffrey shared insights into the group's activities, including fostering connections between academics, industry professionals, and nonprofits, and creating a hybrid model to engage participants from across the state. He also discussed his passion for package development, open science initiatives like the Many Dogs Project, and the challenges of building an inclusive R ecosystem in a geographically dispersed region.
 
-![](JeffreyStevens.png)
+![](JeffreyStevens.png){fig-alt="Jeffrey Stevens"}
 
 
 
@@ -28,7 +28,7 @@ In the last three years, I have also ventured into package development. To date,
 
 I teach R to diverse learners, including undergraduates, graduate students, postdocs, lab managers, and some faculty members. Additionally, I serve as a data science mentor for [Posit](https://posit.co/), guiding corporate individuals through data science training programs. In this role, I lead cohorts of employees seeking to enhance their R and data science skills. I have participated in several of these mentoring sessions, and my extensive experience with R has made it an essential part of my daily work.
 
-![](NebraskaRUGlogo.png)
+![](NebraskaRUGlogo.png){fig-alt="Nebraska RUG logo"}
 
 ## What was your motivation behind starting this R User group?
 
@@ -57,7 +57,7 @@ All attendees at the kickoff meeting were from academia or involved in nonprofit
 
 I highlighted this topic in my email, emphasizing the desire for industry partners to participate and share their insights. The academic participants are significantly interested in how to transition to industry positions, an area I feel more comfortable discussing.
 
-![](NebRUGCollinBerke.png)
+![](NebRUGCollinBerke.png){fig-alt="Nebraska RUG Collin Berke"}
 Nebraska R User Group Kickoff Meeting: [Collin Berke](https://www.collinberke.com/)
 
 
@@ -66,7 +66,7 @@ Nebraska R User Group Kickoff Meeting: [Collin Berke](https://www.collinberke.co
 
 The kickoff meeting was fantastic. As I mentioned last year, the original group consisted of about five or six people from the university. Typically, only four of us met each month, which was relatively small. However, we had 20 people in attendance for the kickoff meeting, which was great! It was mostly folks from Lincoln; unfortunately, no one from Omaha could make it since the meeting was in person.
 
-![](NebRUGRachelRogers.png)
+![](NebRUGRachelRogers.png){fig-alt="Nebraska RUG Rachel Rogers"}
 Nebraska R User Group Kickoff Meeting: [Rachel Rogers](https://www.linkedin.com/in/rachelesrogers/)
 
 I was excited about the turnout, mainly because most attendees were academics I already knew. Still, I also met a few new people from the university. Additionally, we had representatives from [Nebraska Public Media](https://nebraskapublicmedia.org/en/watch/live/?gad_source=1\&gclid=Cj0KCQiAqL28BhCrARIsACYJvkc0RJUmqAJrWTGT1J6o9P0anRam3rJyxk4FKHEJHotsnaxDMe_AClUaApW9EALw_wcB) and [Nebraska Game and Parks](https://members.grownebraska.org/list/member/nebraska-game-and-parks-164?utm_source=google\&gad_source=1\&gclid=Cj0KCQiAqL28BhCrARIsACYJvkdMY_i--W_KWOLTzLpze8Izpcet2qEWRrFwRpTk0UPC00QdMMI9Nd4aAkCIEALw_wcB), which was exciting because it included some nonprofit and governmental groups. 
@@ -77,7 +77,7 @@ My main goal for the kickoff meeting was facilitating communication among the at
 
 We included a couple of lightning talks in the agenda. These were short, five-minute presentations showcasing the various projects participants had been working on. The aim was to help everyone build connections and gain insight into their peers' work. 
 
-![](NebRUGParticipants.png)
+![](NebRUGParticipants.png){fig-alt="Nebraska RUG participants"}
 Nebraska R User Group Kickoff Meeting: Participants
 
 

--- a/posts/connecting-pharma-students-and-r-ronak-shah-on-strengthening-pune-r-ecosystem/index.qmd
+++ b/posts/connecting-pharma-students-and-r-ronak-shah-on-strengthening-pune-r-ecosystem/index.qmd
@@ -6,13 +6,13 @@ description: "Ronak Shah, co-organizer of the Pune R User Group in India, is ene
 categories: ["rugs", "software development", "pharma"]
 author: "R Consortium"
 image: "RonakShah-main-image.png"
-image-alt: "picture of Ronah Shah, Pune R User Group organizer"
+image-alt: "Ronah Shah, Pune R User Group organizer"
 date: "12/02/2025"
 ---
 
 [Ronak Shah](https://www.linkedin.com/in/shahronak47/?originalSubdomain=in), co-organizer of the [Pune R User Group](https://www.meetup.com/pune-r-userr-group/) in India, is energizing a growing R community that connects students, professionals, and data enthusiasts across the city. Through in-person and online meetups, the group fosters collaboration and learning while supporting R’s expanding role in India’s pharmaceutical industry. Ronak also discussed his side project, Package Reviewer, a Shiny app that enables users to rate and review R packages, helping others discover reliable tools within the R ecosystem.
 
-![](RonakShah.png){width=50%}
+![](RonakShah.png){fig-alt="Ronah Shah, Pune R User Group organizer" width=50%}
 
 ## Please share your background and involvement with the RUGS group.
 
@@ -28,7 +28,7 @@ Currently, I work with [Roche](https://www.rocheindia.com/), a pharmaceutical co
 
 In Pune specifically, about 50% of our R user group consists of master's students. They are studying R as part of their coursework and are also conducting projects using R. This has led to a strong interest in the meetups we organize, and I see a lot of traction and growth happening in this area as well.
 
-![](PuneRUGMeetup1.png)
+![](PuneRUGMeetup1.png){fig-alt="Pune RUG Meetup participants selfie 1"}
 
 ## Are you currently hosting your meetups online, in person, or in a hybrid format?
 
@@ -42,7 +42,7 @@ We want to analyze what has gone well and identify areas for improvement and cha
 
 Initially, we focused on the basics of R, but now we plan to move on to some advanced topics. We have also hosted a couple of sessions on introduction to Shiny, including a hands-on workshop. We would now like to introduce more advanced-level topics in R, which we plan to cover in the coming months.
 
-![](PuneRUGMeetup2.png)
+![](PuneRUGMeetup2.png){fig-alt="Pune RUG Meetup participants selfie 2"}
 
 ## What challenges have you faced while organizing the group?
 

--- a/posts/gergely-daroczis-journey-empowering-r-users-in-hungary/index.qmd
+++ b/posts/gergely-daroczis-journey-empowering-r-users-in-hungary/index.qmd
@@ -11,7 +11,7 @@ format:
 url: "https://r-consortium.org/posts/gergely-daroczis-journey-empowering-r-users-in-hungary/"
 unpublished: false
 categories: ["rugs", "events", "ai", "north america"]
-image-alt: "Gergely Daróczi’s Journey: Empowering R Users in Hungary"
+image-alt: "Gergely Daróczi, founder of the Budapest Users of R Network"
 
 ---
 
@@ -24,7 +24,7 @@ Gergely Daróczi, the founder and organizer of the [Budapest Users of R Network]
 <div class="container">
   <div class="row align-items-center">
   <div class="col-md-4">
-  <img src="Untitled.jpg" class="img-fluid" alt="Gergely Daróczi">
+  <img src="Untitled.jpg" class="img-fluid" alt="Gergely Daróczi, founder of the Budapest Users of R Network">
   </div>
   <div class="col-md-8">
   <p>
@@ -41,7 +41,7 @@ Gergely Daróczi, the founder and organizer of the [Budapest Users of R Network]
 
 
 
-![](Untitled%20(1).jpg)
+![](Untitled%20(1).jpg){fig-alt="Budapest R User Group early community meeting"}
 
 
 I have a background in social sciences, and it was during one of my university classes 20 years ago that I was introduced to the R language. We had to use R to run simulations related to the chaotic behavior of the Hungarian potato market. I found R more enjoyable and versatile than other GUI tools like IBM’s SPSS and started using it for other projects as well. Later, I even developed some additional packages for R.
@@ -54,7 +54,7 @@ In 2013, I attended my first [useR! conference](https://www.r-project.org/confer
 
 
 
-![](Untitled%20(2).jpg)
+![](Untitled%20(2).jpg){fig-alt="Budapest R User Group event with guest speakers including Hadley Wickham"}
 
 
 In Hungary, the community’s growth began slowly, with only 20 to 30 members in the first few years. However, it gradually increased over time. The community also hosted some famous personalities such as [Romain Francois](https://www.linkedin.com/in/romain-francois/), Matt Dowle, and [Hadley Wickham](https://www.rstudio.com/authors/hadley-wickham/), which further accelerated its growth. Additionally, the community organized the [first satRday](https://budapest.satrdays.org/) and [second ERUM conference](https://2018.erum.io/), which provided a platform for networking and knowledge sharing, further strengthening the community.
@@ -63,7 +63,7 @@ In Hungary, the community’s growth began slowly, with only 20 to 30 members in
 
 
 
-![](Untitled%20(3).jpg)
+![](Untitled%20(3).jpg){fig-alt="Budapest R User Group in-person meetup after COVID"}
 
 
 **How has the group been doing since our last conversation?**
@@ -74,7 +74,7 @@ After COVID, restarting the meetups was very challenging. We didn’t organize a
 
 
 
-![](Untitled%20(4).jpg)
+![](Untitled%20(4).jpg){fig-alt="Budapest R User Group bioinformatics lightning talks event"}
 
 
 Recently, we have been focusing on bioinformatics and I was introduced to a local company that offered help with reaching out to speakers. Speakers drive these community meetings by bringing in a topic for discussion and talk, which we continue to discuss later on. Our past few events have focused on life sciences and have followed a lightning talk format, where we had around five 15-minute talks at each event. The topics were diverse, covering life sciences, some with LLMs involved, others focused on highly advanced math for modeling. We also had shiny applications that showed the biodiversity of forests in Hungary and some open-source tools besides R. 
@@ -87,7 +87,7 @@ I can only offer subjective experiences on the matter, but I have witnessed the 
 
 
 
-![](Untitled%20(5).jpg)
+![](Untitled%20(5).jpg){fig-alt="Budapest R User Group networking session with food and drinks"}
 
 
 It is important to have a room with plenty of chairs and a larger area for people to gather after the talks. We can provide soft drinks, beer, or wine along with some pizzas and have a chat for an hour or two after the talk. The venue is a crucial factor. It’s also important to have speakers who are interested in the community so that they will come to learn as well. It’s great to have speakers with interesting topics, but the most important thing for me is networking. After the talks, coming together and getting to know others, learning about their struggles, and maybe sharing some tips in person with each other, becoming friends, or learning about opportunities in other industries. Networking and facilitating connections are crucial tasks for R user group organizers.
@@ -104,7 +104,7 @@ I’m excited that COVID restrictions are easing up and meetups are returning to
 
 
 
-![](Untitled.png)
+![](Untitled.png){fig-alt="Spare Cores cloud compute resources project related to R bindings"}
 
 
 Currently, I’m focusing on the ETL pipeline of the [Spare Cores](https://sparecores.com/) project, collecting information on cloud compute resources, which will soon have the R bindings as well. In the past, I’ve been working on R packages related to reporting (e.g. “[pander](https://cran.r-project.org/web/packages/pander/index.html)”) and using R in production (e.g. “[logger](https://cran.r-project.org/web/packages/logger/index.html),” “[dbr](https://github.com/daroczig/dbr)” or “boto3”). Recently, I enjoyed integrating APIs and frameworks from other programming languages, such as Python (kudos to the [reticulate](https://rstudio.github.io/reticulate/) team!), in R.

--- a/posts/keith-karani-wachira-leading-the-dekut-r-community-in-kenya-and-innovating-with-r/index.qmd
+++ b/posts/keith-karani-wachira-leading-the-dekut-r-community-in-kenya-and-innovating-with-r/index.qmd
@@ -7,10 +7,10 @@ date: "06/11/2024"
 url: "https://r-consortium.org/posts/keith-karani-wachira-leading-the-dekut-r-community-in-kenya-and-innovating-with-r/"
 unpublished: false
 categories: ["pharma", "rugs", "events", "ai", "africa"]
-image-alt: "Keith Karani Wachira: Leading the Dekut R Community in Kenya and Innovating with R"
+image-alt: "Keith Karani Wachira, organizer of the Dekut R Community in Nyeri, Kenya"
 
 ---
-![](unnamed.jpg)
+![](unnamed.jpg){fig-alt="Keith Karani Wachira, organizer of the Dekut R Community in Nyeri, Kenya"}
 
 [Keith Karani Wachira](https://www.linkedin.com/in/karani-keith-3794041a4/?originalSubdomain=ke), the [Dekut R Community ](https://www.meetup.com/dekutrcommunity/)organizer based in Nyeri, Kenya, was recently interviewed by the R Consortium and shared his journey in the R community, which began in 2019 during his university years. Sparked by a tech meetup, Keith’s interest grew through the pandemic sessions. Now in academia, he uses R to address business automation challenges, attracting industry professionals to his practical sessions. Excited by trends like AI integration and tools like Quarto, Keith foresees increased automation and efficiency. Outside work, he enjoys baseball, graphic design, web development, and teaching R, finding great reward in his students’ success.
 
@@ -30,7 +30,7 @@ I continued attending the sessions in 2020 during the pandemic. Although we no l
 
 
 
-![](unnamed%20(1).jpg)
+![](unnamed%20(1).jpg){fig-alt="Dekut R Community meetup session in 2020 during the pandemic"}
 
 
 Throughout 2020, I attended regularly but still lacked confidence in the language. However, in 2022, I made significant progress. Under Eric’s leadership, we expanded the community to involve more people, especially students from the department of Actuarial Science, Telecommunication Engineering and electrical engineering. We set up a structured learning environment based on materials from Hadley Wickham’s books and resources from the R website and blogs.
@@ -49,7 +49,7 @@ Coming from a background in business and information technology, I focus on solv
 
 
 
-![](unnamed%20(2).jpg)
+![](unnamed%20(2).jpg){fig-alt="Dekut R Community hybrid session with Egerton University students learning tidy models"}
 
 
 An interesting scenario arose when I became interested in EMS (Engineering and Management Systems). We started organizing hybrid sessions after the COVID period and it caught interest of students from another university in Kenya ,Egerton University. Through, statistical analysis bureau of Egerton University they joined our sessions to learn how to leverage tidy models packages to create machine learning models and also collaborate with the community members.
@@ -60,7 +60,7 @@ They were very interested, and as future economists, we demonstrated how to buil
 
 
 
-![](unnamed.png)
+![](unnamed.png){fig-alt="Dekut R Community session on generating reports with R Markdown"}
 
 
 Another valuable skill we taught was generating reports using R Markdown. This allows users to write code, format text, add videos, images, and emojis, and present their work in a professional and engaging manner. Attendees found this particularly useful as it enhanced their ability to write, structure, and report code effectively.
@@ -71,7 +71,7 @@ Participants learned to leverage the R ecosystem for coding, structuring their w
 
 
 
-![](unnamed%20(3).jpg)
+![](unnamed%20(3).jpg){fig-alt="Dekut R Community members at a learning session"}
 
 
 **What trends do you currently see in R language and your industry? Any trends you see developing in the near future?**
@@ -88,7 +88,7 @@ The integration of AI will likely lead to the automation of many manual processe
 
 
 
-![](unnamed%20(4).jpg)
+![](unnamed%20(4).jpg){fig-alt="Keith Karani Wachira playing baseball as catcher"}
 
 
 When not in front of my laptop, I enjoy playing baseball and softball, especially as a catcher. Catching allows me to see the entire game command the play, and I enjoy throwing the ball from home to second base and picking off a runner. It’s a challenging position that helps me focus and improve my aim.

--- a/posts/learning-shiny-together-a-collaborative-reading-club-around-mastering-shiny-in-buenos-aires/index.qmd
+++ b/posts/learning-shiny-together-a-collaborative-reading-club-around-mastering-shiny-in-buenos-aires/index.qmd
@@ -10,7 +10,7 @@ image-alt: "Mastering Shiny book cover and R-Ladies Buenos Aires logo"
 date: "11/04/2025"
 ---
 
-![](portadashiny.png)
+![](portadashiny.png){fig-alt="Mastering Shiny book cover and R-Ladies Buenos Aires logo"}
 
 Have you ever wanted to read Mastering Shiny but kept postponing it for "when things calm down"? So did we! At [R-Ladies Buenos Aires](https://rladiesba.netlify.app/) and [R en Buenos Aires](https://renbaires.github.io/), many of us had Mastering Shiny sitting on our virtual shelves, always waiting for the right moment. After months (okay, maybe years) of good intentions and no progress, we realized we needed a push, and that push came from the power of community. 
 
@@ -27,11 +27,9 @@ Our goals were simple. We wanted to create a friendly, welcoming environment for
 ::: {.columns}
 ::: {.column width="40%"}
 
-<br>
+![Virtual Meeting 9: Discussion of Chapters 14 of *Mastering Shiny*](shiny1.png){fig-align="center" width="90%" fig-alt="Virtual Meeting 9 of the Mastering Shiny reading club discussing Chapter 14"}
 
-![](shiny1.png){fig-align="center" width="90%" fig-cap="Virtual Meeting 9: Discussion of Chapters 14 of *Mastering Shiny*"} 
-
-![Virtual Meeting 9: Discussion of Chapters 14 of *Mastering Shiny*](shiny3.png){fig-align="center" width="90%" fig-cap="Virtual Meeting 9: Discussion of Chapters 14 of *Mastering Shiny*"} 
+![Virtual Meeting 9: Discussion of Chapters 14 of *Mastering Shiny*](shiny3.png){fig-align="center" width="90%" fig-alt="Virtual Meeting 9 of the Mastering Shiny reading club discussing Chapter 14"}
 
 :::
 
@@ -51,7 +49,7 @@ Most presenters created slides or notebooks to guide their sessions (though this
 Over time, participants started to share the Shiny apps they were building on their own. We added a small "Show and Tell" section to the beginning of some meetings, where people presented their work-in-progress and received feedback and encouragement.
 It was a space full of mutual support, curiosity, and honest learning.
 
-![Summary of the Reading Club's Last Meeting](shiny2.png){fig-align="center" width="90%" fig-cap="Summary of the Reading Club's Last Meeting"}
+![Summary of the Reading Club's Last Meeting](shiny2.png){fig-align="center" width="90%" fig-alt="Summary slide from the last meeting of the Mastering Shiny reading club"}
 
 
 Although we recorded the sessions, we decided to make them accessible only to attendees. This was different from our chapters' usual practice, but we wanted to keep the sessions informal, comfortable, and pressure-free — more like a study group than a workshop. This allowed everyone to feel safe sharing unfinished work, asking questions, and making mistakes. 
@@ -117,7 +115,7 @@ This reading club wasn't just about working through a technical book. It was abo
 ::: {.columns}
 ::: {.column width="30%"}
 
-![](https://avatars.githubusercontent.com/u/38664570?s=200&v=4){width=80% fig-align="center"}
+![](https://avatars.githubusercontent.com/u/38664570?s=200&v=4){width=80% fig-align="center" fig-alt="R-Ladies Buenos Aires logo"}
 
 :::
 
@@ -138,7 +136,7 @@ This reading club wasn't just about working through a technical book. It was abo
 ::: {.columns}
 ::: {.column width="30%"}
 
-![](https://renbaires.github.io/image/BA-1.png){width=70% fig-align="center"}
+![](https://renbaires.github.io/image/BA-1.png){width=70% fig-align="center" fig-alt="R en Buenos Aires user group logo"}
 
 :::
 

--- a/posts/quantifying-participation-risk-with-r-and-r-shiny-a-new-frontier-in-financial-risk-modeling/index.qmd
+++ b/posts/quantifying-participation-risk-with-r-and-r-shiny-a-new-frontier-in-financial-risk-modeling/index.qmd
@@ -7,14 +7,14 @@ date: "05/21/2025"
 url: "https://r-consortium.org/posts/quantifying-participation-risk-with-r-and-r-shiny-a-new-frontier-in-financial-risk-modeling/"
 unpublished: false
 categories: ["insurance/risk", "events", "infrastructure"]
-image-alt: "Quantifying Participation Risk with R and R Shiny: A New Frontier in Financial Risk Modeling"
+image-alt: "Quantifying participation risk with R and R Shiny webinar promotional image"
 
 ---
 
 
 Financial institutions are increasingly looking beyond traditional market risk to quantify and manage more complex forms of risk. [In a recent R Consortium webinar](https://r-consortium.org/webinars/quantification-of-participation-risk-using-r-and-rshiny.html), Goran Lovric, LL.M., and Simon Aigner, MSc, from Raiffeisenlandesbank Oberösterreich (RLB OÖ) unveiled a novel approach to modeling *participation risk* using R and R Shiny, empowering banks to analyze value fluctuations in corporate holdings with a reproducible, open-source solution.
 
-![](goran.jpeg){width=40%}![](simon.jpeg){width=40%}
+![](goran.jpeg){fig-alt="Goran Lovric, LL.M., financial risk management expert at Raiffeisenlandesbank Oberösterreich"}![](simon.jpeg){fig-alt="Simon Aigner, MSc, economic and business analytics professional at Raiffeisenlandesbank Oberösterreich"}
 
 ## From Market Price to Participation Value
 
@@ -30,7 +30,7 @@ Using the `ecb` R package, participants saw how to fetch interest rate curves di
 
 These datasets form the foundation for estimating future cash flows and cost of equity, key components in the discounted cash flow model used to simulate value at risk (VaR) for participations.
 
-![](data.png)
+![](data.png){fig-alt="Screenshot of R code fetching financial data from the European Central Bank using the ecb package"}
 
 ## The R and Shiny App: Simulation, Reporting, and Deployment
 
@@ -40,7 +40,7 @@ All of these capabilities are built into a custom R Shiny app that the speakers 
 
 One striking example from the presentation illustrated the power of diversification. “Let’s say a portfolio is worth €1.7 billion. If you ignore sector correlations, you’d get a risk of €9.9 billion—58%,” Lovric explained. “But if you incorporate actual correlations across different sectors, that drops to about €750 million, or 44.5%, over a one-year, 99.9% confidence interval.”
 
-The tool includes a database-backed architecture for scalability, and Lovric detailed how it can be deployed on an internal server with a few additional scripts. This ensures compliance with banking regulations while preserving accessibility for teams across departments.![](demo.png)
+The tool includes a database-backed architecture for scalability, and Lovric detailed how it can be deployed on an internal server with a few additional scripts. This ensures compliance with banking regulations while preserving accessibility for teams across departments.![](demo.png){fig-alt="Screenshot of the participation risk R Shiny app showing Monte Carlo simulation results"}
 
 ## A Launchpad for Future Collaboration
 

--- a/posts/r-consortiums-submission-working-group-advancing-r-for-regulatory-success-at-pharmasug-2024/index.qmd
+++ b/posts/r-consortiums-submission-working-group-advancing-r-for-regulatory-success-at-pharmasug-2024/index.qmd
@@ -12,7 +12,7 @@ image-alt: "R Consortium’s Submission Working Group: Advancing R for Regulator
 
 ---
 
-![PSUg 2024](psug2024.jpg)
+![PharmaSUG 2024](psug2024.jpg){fig-alt="PharmaSUG 2024 conference session on R for regulatory submissions"}
 
 The R Submission Working Group is making significant strides in promoting the use 
 of R for regulatory submissions in the pharmaceutical industry. At 

--- a/posts/the-impact-of-r-on-academic-excellence-in-manchester-uk/index.qmd
+++ b/posts/the-impact-of-r-on-academic-excellence-in-manchester-uk/index.qmd
@@ -7,7 +7,7 @@ url: "https://r-consortium.org/posts/the-impact-of-r-on-academic-excellence-in-m
 unpublished: false
 categories: ["rugs", "events", "ai", "eu"]
 image: "media.jpg"
-image-alt: "The Impact of R on Academic Excellence in Manchester, UK"
+image-alt: "Martín Herrerías Azcué, Research Software Engineer at the University of Manchester"
 
 ---
 
@@ -15,25 +15,25 @@ The R Consortium recently spoke with the organizing team of the [R User Group at
 
 During the discussion, the team shared details about their recent events and their plans for this year. They also discussed the latest trends in the R programming language and how they are utilizing it in their work.
 
-![](media.jpg)
+![](media.jpg){fig-alt="Martín Herrerías Azcué, Research Software Engineer at the University of Manchester"}
 
 [Martín Herrerías Azcué](https://www.linkedin.com/in/martinherrerias/)  
 Research Software Engineer  
 University of Manchester
 
-![](Screenshot-2024-04-15-at-1.30.33 PM.webp)
+![](Screenshot-2024-04-15-at-1.30.33 PM.webp){fig-alt="Anthony Evans, Research Software Engineer at the University of Manchester"}
 
 Anthony Evans  
 Research Software Engineer  
 University of Manchester
 
-![](media2.jpg)
+![](media2.jpg){fig-alt="Lana Bojanić, PhD Candidate at the University of Manchester"}
 
 [Lana Bojanić](https://www.linkedin.com/in/lana-bojani%C4%87-344b6696/?originalSubdomain=uk)  
 Researcher PhD Candidate  
 University of Manchester
 
-![](media3.jpg)
+![](media3.jpg){fig-alt="Rowan Green, PhD Student in Evolutionary Microbiology at the University of Manchester"}
 
 [Rowan Green](https://www.linkedin.com/in/rowan-green-microbes/?originalSubdomain=uk)  
 PhD Student in Evolutionary Microbiology   
@@ -61,7 +61,7 @@ Martin: Our events are a mix of in-person and online meetings. There have been t
 
 Our book club has mostly or completely taken place online.
 
-![](1000048419.jpg)
+![](1000048419.jpg){fig-alt="R User Group at the University of Manchester book club discussing R for Data Science"}
 
 Lana:  Bookclub was mostly online. During the summer book club, we were reading [R for Data Science](https://r4ds.hadley.nz/). We covered a chapter or two chapters each time. We had the book’s second edition, and people from all over the university joined the club.
 

--- a/webinars/r-medicine-quarto-for-reproducible-medical-manuscripts.qmd
+++ b/webinars/r-medicine-quarto-for-reproducible-medical-manuscripts.qmd
@@ -26,6 +26,6 @@ In this talk, we’ll demo how Quarto manuscripts work and how you can incorpora
 
 ## Speaker
 
-![](images/Mine.png)
+![](images/Mine.png){fig-alt="Mine Çetinkaya-Rundel, Professor of the Practice of Statistical Science at Duke University"}
 
 Mine Çetinkaya-Rundelis, is Professor of the Practice of Statistical Science and the Director of Undergraduate Studies in the Department of Statistical Science, as well as an affiliated faculty member in the Computational Media, Arts, and Cultures program at Duke University. Her work is dedicated to advancing innovation in statistics and data science pedagogy, focusing particularly on computing, reproducible research, student-centered learning, and open-source education. She emphasizes integrating computation into the undergraduate statistics curriculum, employing reproducible research methodologies, and analyzing real and complex datasets. In Spring 2024, she will be teaching STA 199 – Introduction to Data Science and Statistical Thinking, along with STA 313 – Advanced Data Visualization. Further details about her work can be explored below, or she can be found on Mastodon and Bluesky.

--- a/webinars/webinars.qmd
+++ b/webinars/webinars.qmd
@@ -16,125 +16,125 @@ If there is some information that you are looking for specifically and you don't
 
 ## Archived Webinars – Full Recordings Available
 
-![](images/rmedicine-webinar-garrett-grolemund-main-image.png){width=60%}
+![](images/rmedicine-webinar-garrett-grolemund-main-image.png){width=60% fig-alt="Webinar banner: Use AI to build and share insights from health data"}
 
 Learn more: [Use AI to build and share insights from health data](use-ai-to-build-and-share-insights-from-health-data.qmd)
 
-![](images/rmedicine-webinar-daniel-chen.jpg){width=60%}
+![](images/rmedicine-webinar-daniel-chen.jpg){width=60% fig-alt="Webinar banner: Make your first R open source project contribution with git, forks, and PRs"}
 
 Learn more: [Make your first R open source project contribution with git, forks, and PRs](make-your-first-r-open-source-project-contribution.qmd)
 
-![](images/crane-arrow-webinar-main-image.png){width=60%}
+![](images/crane-arrow-webinar-main-image.png){width=60% fig-alt="Webinar banner: Scaling up data analysis in R with Arrow"}
 
 Learn more: [Scaling up data analysis in R with Arrow](scaling-up-data-analysis-in-r-with-arrow.qmd)
 
-![](images/HTA-making-health-economic-models-healthy-main-image.png){width=60%}
+![](images/HTA-making-health-economic-models-healthy-main-image.png){width=60% fig-alt="Webinar banner: Making Health Economic Models Shiny: transitioning from Excel to R and Shiny"}
 
 Learn more: [Making Health Economic Models Shiny: Our experience helping companies transition from Excel to R & Shiny](making-health-economic-models-shiny.qmd)
 
-![](images/rmedicine-webinar-posit-pointblack-main-image.jpg){width=60%}
+![](images/rmedicine-webinar-posit-pointblack-main-image.jpg){width=60% fig-alt="Webinar banner: How to use pointblank to understand, validate, and document your data"}
 
 Learn more: [How to use pointblank to understand, validate, and document your data](how-to-use-pointblank-to-understand-validate-and-document-your-data.qmd)
 
-![](images/jnj-submission-webinar-main-image.png){width=60%}
+![](images/jnj-submission-webinar-main-image.png){width=60% fig-alt="Webinar banner: J&J: A Hybrid SAS/R Submission Story"}
 
 Learn more: [J&J: A Hybrid SAS/R Submission Story](jnj-hybrid-sas-r-submission-story.qmd)
 
-![](images/webinar-topological-cory-aymeric-main-image.png){width=60%}
+![](images/webinar-topological-cory-aymeric-main-image.png){width=60% fig-alt="Webinar banner: Modular, interoperable, and extensible topological data analysis in R"}
 
 Learn more: [Modular, interoperable, and extensible topological data analysis in R](modular-interoperable-extensible-topological-data-analysis-in-r.qmd)
 
-![](images/sas-to-r-procogia-main-image.png){width=60%}
+![](images/sas-to-r-procogia-main-image.png){width=60% fig-alt="Webinar banner: SAS to R in Pharma – Creating Custom Solutions for Closed-Source Code"}
 
 Learn more: [SAS to R in Pharma – Creating Custom Solutions for Closed-Source Code](sas-to-r-in-pharma-creating-custom-solutions-for-closed-source-code.qmd)
 
-![](images/webinar-git-githubcicd-llms-in-pharma-ERIC.png){width=60%}
+![](images/webinar-git-githubcicd-llms-in-pharma-ERIC.png){width=60% fig-alt="Webinar banner: Unlocking Collaborative Power with Git, GitHub CI/CD, and LLMs in Pharma"}
 
 Learn more: [Unlocking Collaborative Power with Git, GitHub CI/CD, and LLMs in Pharma](unlocking-collaborative-power-with-git-github-ci-cd-and-llms-in-pharma.qmd)
 
-![](images/webinar-jpma-july-2025.png){width=60%}
+![](images/webinar-jpma-july-2025.png){width=60% fig-alt="Webinar banner: Open Source Software Adoption in Japan's Pharma Industry: 2024 JPMA R Usage Survey"}
 
 Learn more: [Open Source Software Adoption in Japan's Pharma Industry: Key Findings from the 2024 JPMA R Usage Survey](open-source-adoption-in-japans-pharma-industry.qmd)
 
-![](images/hta-wg-webinar-main-image.png){width=60%}
+![](images/hta-wg-webinar-main-image.png){width=60% fig-alt="Webinar banner: R for Health Technology Assessment: Identifying Needs, Streamlining Processes, and Building Bridges"}
 
 Learn more: [R for Health Technology Assessment (HTA): Identifying Needs, Streamlining Processes, and Building Bridges](r-for-health-technology-assessment-identifying-needs-streamlining-processes-and-building-bridges.qmd)
 
-![](images/virginia-deq-webinar-main-image.png){width=60%}
+![](images/virginia-deq-webinar-main-image.png){width=60% fig-alt="Webinar banner: From Paper to Pixels: Digitizing Water Quality Data Collection with Posit and Esri Integration"}
 
 Learn more: [From Paper to Pixels: Digitizing Water Quality Data Collection with Posit and Esri Integration](from-paper-to-pixels-digitizing-water-quality-data-collection-with-posit-and-esri-integration.qmd)
 
-![](images/dewey-webinar-main-image.png){width=60%}
+![](images/dewey-webinar-main-image.png){width=60% fig-alt="Webinar banner: Scaling the r-spatial ecosystem for the modern composable data pipeline"}
 
 Learn more: [Scaling the r-spatial ecosystem for the modern composable data pipeline](scaling-the-r-spatial-ecosystem-for-the-modern-composable-data-pipeline.qmd)
 
-![](images/oracle-webinar-veronica-main-image.png){width=60%}
+![](images/oracle-webinar-veronica-main-image.png){width=60% fig-alt="Webinar banner: Super-charging R with Oracle Database: Getting Started with the ROracle Driver"}
 
 Learn more: [Super‑charging R with Oracle Database: Getting Started with the ROracle Driver](super-charging-r-with-oracle-database.qmd)
 
 
-![](images/R-Medicine-Webinar-2025-Bruno-Rodrigues-1110-x-564px.png){width=60%}
+![](images/R-Medicine-Webinar-2025-Bruno-Rodrigues-1110-x-564px.png){width=60% fig-alt="Webinar banner: Rix: reproducible data science environments with Nix"}
 
 Learn more: [Rix: reproducible data science environments with Nix](rix-reproducible-data-science-environments-with-nix.qmd)
 
-![](images/quantification-of-participation-risk-main-image.png){width=60%}
+![](images/quantification-of-participation-risk-main-image.png){width=60% fig-alt="Webinar banner: Quantification of participation risk using R and RShiny"}
 
 Learn more: [Quantification of participation risk using R and RShiny](quantification-of-participation-risk-using-r-and-rshiny.qmd)
 
-![](images/tiny-finance-main-image.jpg){width=60%}
+![](images/tiny-finance-main-image.jpg){width=60% fig-alt="Webinar banner: Tidy Finance Webinar Series"}
 
 Learn more: [Tidy Finance Webinar Series](tidy-finance-webinar-series.qmd)
 
 
-![](images/latinr-webinar-main-page.png){width=60%}
+![](images/latinr-webinar-main-page.png){width=60% fig-alt="Webinar banner: Unlocking Insights from LatinR: Collaboration and Innovation in Data Science"}
 
 Learn more: [Unlocking Insights from LatinR: Collaboration and Innovation in Data Science Webinar](unlocking-insights-from-latinr.qmd)
 
-![](images/containerization-and-r-webinar-main-image.png){width=60%}
+![](images/containerization-and-r-webinar-main-image.png){width=60% fig-alt="Webinar banner: Containerization and R for Reproducibility and More"}
 
 Learn more: [Containerization and R for Reproducibility and More](containerization-and-r-for-reproducibility.qmd)
 
-![](images/quarto-for-reproducable-medical-manuscripts.webp){width=60%}
+![](images/quarto-for-reproducable-medical-manuscripts.webp){width=60% fig-alt="Webinar banner: R/Medicine: Quarto for Reproducible Medical Manuscripts"}
 
 Learn more: [R/Medicine: Quarto for Reproducible Medical Manuscripts](r-medicine-quarto-for-reproducible-medical-manuscripts.qmd)
 
 
-![](images/tidy-finance-and-accessing-financial-data.webp){width=50%}
+![](images/tidy-finance-and-accessing-financial-data.webp){width=50% fig-alt="Webinar banner: Tidy Finance and Accessing Financial Data"}
 
 Learn more: [Tidy Finance and Accessing Financial Data](new-webinar-tidy-finance-and-accessing-financial-data.qmd)
 
 
-![](images/oracle-main-image-escape-the-date-dungeon.png){width=50%}
+![](images/oracle-main-image-escape-the-date-dungeon.png){width=50% fig-alt="Webinar banner: Escape the Data Dungeon: Unlock Scalable R Analytics and ML"}
 
 Learn more: [Escape the Data Dungeon: Unlock Scalable R Analytics and ML](escape-the-data-dungeon.qmd)
 
 
-![](images/pfizer-main-image-from-vision-to-action.png){width=50%}
+![](images/pfizer-main-image-from-vision-to-action.png){width=50% fig-alt="Webinar banner: From Vision to Action: The Pfizer R Center of Excellence-led journey to R Adoption"}
 
 Learn more: [From Vision to Action: The Pfizer R Center of Excellence-led journey to R Adoption](from-vision-to-action-the-pfizer-r-center-of-excellence.qmd)
 
 
-![](images/swissre-main-image-r-insurance-series.png){width=50%}
+![](images/swissre-main-image-r-insurance-series.png){width=50% fig-alt="Webinar banner: R/Insurance Series: For Everyone in Insurance or Actuarial Science"}
 
 Learn more: [R/Insurance Series: For Everyone in Insurance or Actuarial Science](r-insurance-series.qmd)
 
 
-![](images/visualizing-survival-data-with-the-ggsurvfit-r-package-main-image.png){width=50%}
+![](images/visualizing-survival-data-with-the-ggsurvfit-r-package-main-image.png){width=50% fig-alt="Webinar banner: R/Medicine Webinar: Visualizing Survival Data with the ggsurvfit R Package"}
 
 Learn more: [R/Medicine Webinar: Visualizing Survival Data with the {ggsurvfit} R Package](visualizing-survival-data-with-the-ggsurvfit-r-package.qmd)
 
 
-![](https://archive.r-consortium.org/wp-content/uploads/sites/13/2024/01/Screenshot-2024-01-10-at-3.31.52%E2%80%AFPM-1024x574.png){width=50%}
+![](https://archive.r-consortium.org/wp-content/uploads/sites/13/2024/01/Screenshot-2024-01-10-at-3.31.52%E2%80%AFPM-1024x574.png){width=50% fig-alt="Webinar banner: R/Adoption Series — The Adoption of R in Japan's Pharma Industry"}
 
 Learn more: [R/Adoption Series: The Adoption of R in Japan’s Pharma Industry Confirmation](https://archive.r-consortium.org/r-adoption-series-the-adoption-of-r-in-japans-pharma-industry-confirmation)
 
 
-![](https://archive.r-consortium.org/wp-content/uploads/sites/13/2023/10/Screenshot-2023-10-24-at-3.08.23-PM-1024x569.png){width=50%}
+![](https://archive.r-consortium.org/wp-content/uploads/sites/13/2023/10/Screenshot-2023-10-24-at-3.08.23-PM-1024x569.png){width=50% fig-alt="Webinar banner: R/Adoption Series — R and Shiny in regulatory submission"}
 
 Learn more: [R/Adoption Series: R and shiny in regulatory submission](https://archive.r-consortium.org/r-adoption-series-r-and-shiny-in-regulatory-submissions-webinar)
 
 
-![](https://archive.r-consortium.org/wp-content/uploads/sites/13/2023/03/11.png){width=50%}
+![](https://archive.r-consortium.org/wp-content/uploads/sites/13/2023/03/11.png){width=50% fig-alt="Webinar banner: R/Adoption Series — Learnings and Reflection from R Validation Case Studies"}
 
 Learn More: [R/Adoption Series: Learnings and Reflection from R Validation Case Studies](https://archive.r-consortium.org/r-adoption-series-learnings-and-reflection-from-r-validation-case-studies)
 
@@ -147,7 +147,7 @@ Learn More: [R/Adoption Series: Learnings and Reflection from R Validation Case 
 
 <div class="column1">
 <a href="#">
-<img src="https://archive.r-consortium.org/wp-content/uploads/sites/13/2023/01/Webinars-upcoming-banners-6.png" />
+<img src="https://archive.r-consortium.org/wp-content/uploads/sites/13/2023/01/Webinars-upcoming-banners-6.png"  alt="Webinar banner: Teal: An R-Shiny Framework to Unlock the Power of Interactive Data Exploration" />
 </a>
 <p>Learn More: 
 <a href="https://archive.r-consortium.org/r-adoption-series-r-and-shiny-in-regulatory-submissions-webinar">
@@ -159,7 +159,7 @@ Teal: An R-Shiny Framework to Unlock the Power of Interactive Data Exploration
 
 <div class="column1">
 <a href="https://archive.r-consortium.org/r-adoption-series-introducing-the-software-engineering-working-group-and-mmrm">
-<img src="https://archive.r-consortium.org/wp-content/uploads/sites/13/2023/01/9-1.png" />
+<img src="https://archive.r-consortium.org/wp-content/uploads/sites/13/2023/01/9-1.png"  alt="Webinar banner: R Adoption Series: Introducing the Software Engineering Working Group and mmrm" />
 </a>
 <p>Learn More: 
 <a href="https://archive.r-consortium.org/r-adoption-series-r-and-shiny-in-regulatory-submissions-webinar">
@@ -175,7 +175,7 @@ R Adoption Series: Introducing the Software Engineering Working Group and {mmrm}
 
 <div class="column2">
 <a href="#">
-<img src="images/Webinars-upcoming-banners.webp" />
+<img src="images/Webinars-upcoming-banners.webp"  alt="Webinar banner: R/Database: Using R at Scale on Database Data" />
 </a>
 <p>Learn More: 
 <a href="https://archive.r-consortium.org/r-database-using-r-at-scale-on-database-data">
@@ -188,7 +188,7 @@ R/Database: Using R at Scale on Database Data
 
 <div class="column2">
 <a href="#">
-<img src="images/r_insurance.webp" />
+<img src="images/r_insurance.webp"  alt="Webinar banner: Upskilling on Data Handling and Communication at Swiss Re" />
 </a>
 <p>Learn More: 
 <a href="https://archive.r-consortium.org/upskilling-on-data-handling-and-communications-at-swiss-re">
@@ -203,7 +203,7 @@ Upskilling on Data Handling and Communication at Swiss Re
 
 <div class="column2">
 <a href="#">
-<img src="images/WEBINAR-using-metadata-for-speedy-delivery.webp" />
+<img src="images/WEBINAR-using-metadata-for-speedy-delivery.webp"  alt="Webinar banner: Using Metadata for Speedy Delivery" />
 </a>
 <p>Learn More: 
 <a href="https://archive.r-consortium.org/using-metadata-for-speedy-delivery">
@@ -220,7 +220,7 @@ Using Metadata for Speedy Delivery Re
 
 <div class="column2">
 <a href="#">
-<img src="images/Using.webp" />
+<img src="images/Using.webp"  alt="Webinar banner: Using R in Regulatory Review" />
 </a>
 <p>Learn More: 
 <a href="https://archive.r-consortium.org/using-r-in-regulatory-review">
@@ -239,7 +239,7 @@ Using R in Regulatory Review
 
 <div class="column2">
 <a href="#">
-<img src="images/Speaking-Different-Languages.webp" />
+<img src="images/Speaking-Different-Languages.webp"  alt="Webinar banner: Speaking Different Languages: Clinical Statistical Modelling in a World with Choice" />
 </a>
 <p>Learn More: 
 <a href="https://archive.r-consortium.org/speaking-different-languages-clinical-statistical-modelling-in-a-world-with-choice">
@@ -255,7 +255,7 @@ Speaking Different Languages
 
 <div class="column2">
 <a href="#">
-<img src="images/3-Reporting-Table-Creation-In-R.webp" />
+<img src="images/3-Reporting-Table-Creation-In-R.webp"  alt="Webinar banner: Reporting Table Creation in R" />
 </a>
 <p>Learn More: 
 <a href="https://archive.r-consortium.org/reporting-table-creation-in-r">
@@ -270,7 +270,7 @@ Table Creation in R
 
 <div class="column2">
 <a href="#">
-<img src="images/R-Package-Management-at-Roche.webp" />
+<img src="images/R-Package-Management-at-Roche.webp"  alt="Webinar banner: R Package Management at Roche" />
 </a>
 <p>Learn More: 
 <a href="https://archive.r-consortium.org/r-package-management-at-roche">
@@ -287,7 +287,7 @@ R Management at Roche
 
 <div class="column2">
 <a href="#">
-<img src="images/Using-r-in-regulatory-review.webp" />
+<img src="images/Using-r-in-regulatory-review.webp"  alt="Webinar banner: R Training Strategies at Janssen" />
 </a>
 <p>Learn More: 
 <a href="https://archive.r-consortium.org/r-training-strategies-at-janssen">
@@ -304,7 +304,7 @@ R Training Strategies at Janssen
 
 <div class="column2">
 <a href="#">
-<img src="images/Scaling-R-at-GSK.webp" />
+<img src="images/Scaling-R-at-GSK.webp"  alt="Webinar banner: Scaling R at GSK" />
 </a>
 <p>Learn More: 
 <a href="https://archive.r-consortium.org/scaling-r-at-gsk">


### PR DESCRIPTION
## Summary
- Adds accessible alt text across 34 `.qmd` files using Quarto `{fig-alt=...}`, YAML `image-alt`, and HTML `alt` attributes
- Covers reviewed CSV rows F0007–F0101 (73 Accepted rows) plus pilot pages (webinars and selected blog posts)
- Fixes truncated alt text on the Victor Lee Korea RUG post hero image

## Test plan
- [ ] Render a sample of updated blog posts and verify `alt` attributes in HTML output
- [ ] Spot-check webinar listing page images for alt text
- [ ] Confirm no broken image paths after edits