### PR TITLE
Fix duplicate image-alt YAML keys breaking GitHub Pages build

### DIFF
--- a/posts/aligning-belief-and-profession-using-r-in-protecting-the-penobscot-nation-traditional-lifeways-r-consortium/index.qmd
+++ b/posts/aligning-belief-and-profession-using-r-in-protecting-the-penobscot-nation-traditional-lifeways-r-consortium/index.qmd
@@ -12,7 +12,6 @@ format:
 url: "https://r-consortium.org/posts/aligning-belief-and-profession-using-r-in-protecting-the-penobscot-nation-traditional-lifeways-r-consortium/"
 unpublished: false
 categories: ["events", "asia"]
-image-alt: "Aligning Beliefs and Profession: Using R in Protecting the Penobscot Nation’s Traditional Lifeways"
 
 ---
 

--- a/posts/announcing-health-technology-assessment-HTA-working-group/index.qmd
+++ b/posts/announcing-health-technology-assessment-HTA-working-group/index.qmd
@@ -8,7 +8,6 @@ date: "10/01/2024"
 url: "https://r-consortium.org/posts/announcing-health-technology-assessment-HTA-working-group/"
 unpublished: false
 categories: ["pharma", "eu", "working groups"]
-image-alt: "Announcing the Health Technology Assessment (HTA) Working Group"
 
 ---
 

--- a/posts/books-beginners-big-ideas-beatriz-milz-fostering-r-ladies-sao-paulo-community/index.qmd
+++ b/posts/books-beginners-big-ideas-beatriz-milz-fostering-r-ladies-sao-paulo-community/index.qmd
@@ -8,7 +8,6 @@ date: "12/23/2024"
 url: "https://r-consortium.org/posts/books-beginners-big-ideas-beatriz-milz-fostering-r-ladies-sao-paulo-community/"
 unpublished: false
 categories: ["rugs", "events", "ai", "south america", "women in tech"]
-image-alt: "Books, Beginners, and Big Ideas: Beatriz Milz on Fostering R-Ladies São Paulo’s Vibrant Community"
 
 ---
 

--- a/posts/bridging-gaps-and-breaking-barriers-a-year-of-r-innovation-with-the-china-pharmarug/index.qmd
+++ b/posts/bridging-gaps-and-breaking-barriers-a-year-of-r-innovation-with-the-china-pharmarug/index.qmd
@@ -10,7 +10,6 @@ categories: ["asia", "pharma", "events"]
 image: "third-pharmarug-conf.png"
 image-alt: "Bridging Gaps and Breaking Barriers: A Year of R Innovation with the China PharmaRUG"
 date: "12/11/2025"
-image-alt: "Bridging Gaps and Breaking Barriers: A Year of R Innovation with the China PharmaRUG"
 
 ---
 

--- a/posts/bridging-the-digital-divide-umar-isah-adam-on-expanding-r-access-for-kano-nigeria-students/index.qmd
+++ b/posts/bridging-the-digital-divide-umar-isah-adam-on-expanding-r-access-for-kano-nigeria-students/index.qmd
@@ -8,7 +8,6 @@ date: "06/17/2024"
 url: "https://r-consortium.org/posts/bridging-the-digital-divide-umar-isah-adam-on-expanding-r-access-for-kano-nigeria-students/"
 unpublished: false
 categories: ["rugs", "events", "africa"]
-image-alt: "Bridging the Digital Divide: Umar Isah Adam on Expanding R Access for Kano, Nigeria Students"
 
 ---
 

--- a/posts/bridging-the-real-time-gap-how-inwt-is-bringing-apache-kafka-to-the-r-ecosystem/index.qmd
+++ b/posts/bridging-the-real-time-gap-how-inwt-is-bringing-apache-kafka-to-the-r-ecosystem/index.qmd
@@ -8,7 +8,6 @@ date: "11/12/2024"
 url: "https://r-consortium.org/posts/bridging-the-real-time-gap-how-inwt-is-bringing-apache-kafka-to-the-r-ecosystem/"
 unpublished: false
 categories: ["isc", "announcements", "infrastructure"]
-image-alt: "Bridging the Real-Time Gap: How INWT is Bringing Apache Kafka to the R Ecosystem"
 
 ---
 

--- a/posts/building-bridges-in-haifa-israel/index.qmd
+++ b/posts/building-bridges-in-haifa-israel/index.qmd
@@ -8,7 +8,6 @@ date: "08/20/2024"
 url: "https://r-consortium.org/posts/building-bridges-in-haifa-israel/"
 unpublished: false
 categories: ["pharma", "rugs", "events", "middle east"]
-image-alt: "Building Bridges in Haifa, Israel: How the New R User Group in Haifa is Establishing a Diverse R Community"
 
 ---
 

--- a/posts/cakes-code-and-community-reviving-the-copenhagenr-user-group/index.qmd
+++ b/posts/cakes-code-and-community-reviving-the-copenhagenr-user-group/index.qmd
@@ -8,7 +8,6 @@ date: "10/08/2024"
 url: "https://r-consortium.org/posts/cakes-code-and-community-reviving-the-copenhagenr-user-group/"
 unpublished: false
 categories: ["pharma", "rugs", "events", "ai"]
-image-alt: "Cakes, Code, and Community: Rasmus Bååth’s Secret to Reviving the CopenhagenR UseR Group"
 
 ---
 

--- a/posts/clinical-reporting-roches-nest-and-admiral-teams/index.qmd
+++ b/posts/clinical-reporting-roches-nest-and-admiral-teams/index.qmd
@@ -8,7 +8,6 @@ date: "01/15/2025"
 url: "https://r-consortium.org/posts/clinical-reporting-roches-nest-and-admiral-teams/"
 unpublished: false
 categories: ["pharma"]
-image-alt: "A Clinical Reporting Collaborative Triumph: Roche’s NEST and Admiral Teams"
 
 ---
 

--- a/posts/collaborative-growth-the-botswana-r-user-group-and-regional-partnerships/index.qmd
+++ b/posts/collaborative-growth-the-botswana-r-user-group-and-regional-partnerships/index.qmd
@@ -8,7 +8,6 @@ date: "05/24/2024"
 url: "https://r-consortium.org/posts/collaborative-growth-the-botswana-r-user-group-and-regional-partnerships/"
 unpublished: false
 categories: ["rugs", "events", "africa"]
-image-alt: "Collaborative Growth: The Botswana R User Group and Regional Partnerships"
 
 ---
 


### PR DESCRIPTION
## Summary
- Removes duplicate `image-alt` keys from YAML front matter in 10 blog posts
- Fixes `YAMLException: duplicated mapping key` error that failed the GitHub Pages build after #606 merged

## Test plan
- [ ] Verify GitHub Pages build completes successfully
- [ ] Spot-check affected posts render correctly