### PR TITLE
Add accessible alt text to blog posts (batch 2)

### DIFF
--- a/posts/650K-for-R/index.qmd
+++ b/posts/650K-for-R/index.qmd
@@ -12,7 +12,7 @@ date: "12/18/2025"
 
 _Original blog post by Heather Turner here: [RSMF: Enabling the Next Generation of Contributors to R](https://blog.r-project.org/2025/12/17/rsmf-enabling-the-next-generation-of-contributors-to-r/index.html)_
 
-![](650K-grant-main-image.png)
+![](650K-grant-main-image.png){fig-alt="R logo with text saying $650K Awarded to R Foundation"}
 
 From the blog post:
 

--- a/posts/ann-arbor-r-user-group-harnessing-the-power-of-r/index.qmd
+++ b/posts/ann-arbor-r-user-group-harnessing-the-power-of-r/index.qmd
@@ -13,7 +13,7 @@ image-alt: "Ann Arbor R User Group: Harnessing the Power of R and GitHub"
 
 The R Consortium talked to [Barry Decicco](https://www.linkedin.com/in/barrydecicco/), founder, and organizer of the [Ann Arbor R User Group](https://www.meetup.com/ann-arbor-r-user-group/), based in Ann Arbor, Michigan. Barry shared his experience working with R as a statistician and highlighted the current trends in the R language in his industry. He also emphasized the significance of organizing regular events and effective communication for managing an R User Group (RUG).
 
-![](media.jpg)
+![](media.jpg){fig-alt="Barry Decicco, founder, and organizer of the Ann Arbor R User Group"}
 
 **Please share about your background and involvement with the RUGS group.**
 

--- a/posts/bridging-gaps-tunis-r-user-groups-journey-in-democratizing-r-in-bioinformatics/index.qmd
+++ b/posts/bridging-gaps-tunis-r-user-groups-journey-in-democratizing-r-in-bioinformatics/index.qmd
@@ -13,11 +13,11 @@ image-alt: "Bridging Gaps: Tunis R User Group’s Journey in Democratizing R in 
 
 Last year, the R Consortium had a conversation with Amal Tlili, the co-organizer of the [Tunis R User Group](https://www.meetup.com/tunis-r-user-group/), regarding the [Use of R for Marketing and CRM in Tunisia](https://www.r-consortium.org/blog/2023/03/15/use-of-r-for-marketing-and-crm-in-tunisia). This year, [Amal Boukteb](https://twitter.com/AmalBk11) and [Hedia Tnani](https://twitter.com/TnaniHedia) spoke to the R Consortium about the use of R for bioinformatics research in Tunisia and discussed the group’s efforts to bridge the gap between academia and industry. The Tunis R User Group hosts engaging virtual events to connect R enthusiasts across the MENA region and Worldwide. Their events promote the use of R and foster knowledge and skill development in data science and bioinformatics.
 
-![](Screenshot-2024-04-26-at-1.33.06 PM.webp)
+![](Screenshot-2024-04-26-at-1.33.06 PM.webp){fig-alt="Amal Tlili, the co-organizer of the Tunis R User Group"}
 
 > [Amal Boukteb](https://www.linkedin.com/in/amal-boukteb-29a27691/?originalSubdomain=tn) is a PhD student at the National Institute for Agricultural Research of Tunisia (INRAT). She holds master’s degrees in Molecular Genetics and Biostatistics. Her PhD project focuses on _Orobanche foetida_, a parasitic plant threatening faba bean crops. She analyzed O_. foetida_ genetic diversity in Tunisia with RADseq and studied faba bean gene expression during this parasitic plant attack using RNA-seq. With a passion for integrating bioinformatics and Plant biology, Amal is determined to make significant contributions to the implementation of sustainable agricultural practices.
 
-![](media.jpg)
+![](media.jpg){fig-alt="Dr. Hedia Tnani, Staff Scientist at Lieber Institute for Brain Development (LIBD)"}
 
 > Dr. [Hedia Tnani](https://www.linkedin.com/in/hedia-tnani-0095221a7/?originalSubdomain=es) is a Staff Scientist at Lieber Institute for Brain Development (LIBD). She did a PhD in molecular biology and genetics. Her current work focuses on addressing the complex challenge of RNA degradation in postmortem brain tissue samples. She’s also the co-founder of R-Ladies Tunis and Tunis R User Group. Through the Tunis R User Group, she wants to democratize bioinformatics and data science.
 

--- a/posts/bridging-the-digital-divide-umar-isah-adam-on-expanding-r-access-for-kano-nigeria-students/index.qmd
+++ b/posts/bridging-the-digital-divide-umar-isah-adam-on-expanding-r-access-for-kano-nigeria-students/index.qmd
@@ -18,7 +18,7 @@ categories: ["rugs", "events", "africa"]
 
 
 
-![](unnamed.jpg )
+![](unnamed.jpg){fig-alt="Umar Isah Adam, the founder and organizer of the R User Group Kano, Nigeria"}
 
 
 **Please share your background and involvement with the RUGS group.**

--- a/posts/bridging-the-real-time-gap-how-inwt-is-bringing-apache-kafka-to-the-r-ecosystem/index.qmd
+++ b/posts/bridging-the-real-time-gap-how-inwt-is-bringing-apache-kafka-to-the-r-ecosystem/index.qmd
@@ -11,7 +11,7 @@ categories: ["isc", "announcements", "infrastructure"]
 
 ---
 
-![](Andreas.png){width=50%}
+![](Andreas.png){width=50% fig-alt="Andreas Neudecker, solution architect at INWT, a data and analytics company located in Berlin, Germany"}
 
 In a recent interview with the R Consortium, [Andreas Neudecker](https://www.linkedin.com/in/andreas-neudecker-457946208/), solution architect at INWT, a data and analytics company located in Berlin, Germany, shared insights into the motivation behind developing an Apache Kafka client for R and the challenges it aims to address within the R ecosystem. His company frequently builds models in both R and Python, often encountering the need for real-time data analytics from Kafka clusters. When a real-time fraud detection project required connecting to a Kafka cluster, the lack of a stable Kafka client for R forced them to switch to Python despite having an R-based model ready to go. This experience highlighted the gap in R's real-time data processing capabilities. It inspired Andreas to develop a Kafka client for R, making it easier to access real-time data sources and potentially leveling the playing field with Python. 
 

--- a/posts/bringing-students-researchers-and-industry-together-with-r-in-malaysia/index.qmd
+++ b/posts/bringing-students-researchers-and-industry-together-with-r-in-malaysia/index.qmd
@@ -12,7 +12,7 @@ date: "02/05/2026"
 
 [Richie Yu Yong Poh](https://www.linkedin.com/in/yong-poh-yu/?originalSubdomain=my), organizer of the [Malaysia R User Group](https://www.meetup.com/malaysia-r-user-group/), recently spoke with the R Consortium about building a national R community centered around its annual conference. He shared that the group has evolved from a small network into a robust platform that connects students, researchers, and industry practitioners through workshops, seminars, and a flagship two-day event. Richie discussed the logistics of the annual conference, the design of hands-on workshops, and R's role in bridging the gap between academia and industry through real-world applications.
 
-![](YuYongPoh.png){fig-alt="YuYongPoh — Bringing Students, Researchers, and Industry Together with R in Malaysia" width=50%}
+![](YuYongPoh.png){fig-alt="Richie Yu Yong Poh, organizer of the Malaysia R User Group" width=50%}
 
 **Please share about your background and involvement with the RUGS group.**
 

--- a/posts/building-bridges-in-haifa-israel/index.qmd
+++ b/posts/building-bridges-in-haifa-israel/index.qmd
@@ -11,7 +11,7 @@ categories: ["pharma", "rugs", "events", "middle east"]
 
 ---
 
-![](unnamed.jpg)
+![](unnamed.jpg){fig-alt="Eli Eydlin, instrumental in establishing an R User Group in Haifa, Israel"}
 
 The R Consortium recently interviewed [Eli Eydlin](https://www.linkedin.com/in/elieydlin/?originalSubdomain=il), a dedicated member of the R community who has been instrumental in establishing an [R User Group in Haifa, Israel](https://www.meetup.com/haifa-r-user-group/). With a background in physics and a recent shift into the biotech industry, Eli was motivated to create the group after noticing the absence of a local R community in his new city. Despite Haifa’s relatively small size, it boasts a diverse R community, including professionals from high-tech companies, academia, and startups. Eli shared his experience organizing their first Meetup, which featured speakers from vastly different backgrounds, and his plans to make future events more inclusive. His story highlights the importance of community building and the impact of taking the initiative, offering inspiration for others looking to contribute to their local R communities.
 
@@ -21,17 +21,17 @@ I’ve been working in a biotech startup for nearly two years. My background is 
 
 **Can you share what the R community is like in Haifa?** 
 
-![](unnamed2.png)
+![](unnamed2.png){fig-alt="Haifa R User Group logo"}
 
 One of the reasons I started this was to meet new people who are also R programmers or users. I already know that the community is really diverse. My city isn’t huge—around 300,000 people—but has much to offer. There are big high-tech companies like Microsoft and Amazon here that support their R&D departments, and I’m certain that some of our members are involved. Like in many places in Israel, there are hundreds of small startups. What I find interesting is that people come from all sorts of backgrounds—mostly from academia, as usual, but now also from government, traditional companies, and small businesses. I’m excited to see where this leads.
 
 **You had a** [**Meetup on August 6th, 2024**](https://www.meetup.com/haifa-r-user-group/events/302199640/)**. Can you share more about the topic covered? Why this topic**? 
 
-![](unnamed3.png)
+![](unnamed3.png){fig-alt="Haifa R User Group meetup Aug 6, 2024, participants"}
 
 We have two completely different topics and two amazing speakers. [Sofia Nazarova](https://www.linkedin.com/in/snazarova/?trk=public_profile_browsemap_mini-profile_title&originalSubdomain=ru) is a marine biologist at [Israel Oceanographic & Limnological](https://www.ocean.org.il/en/), who also organizes private guided tours. She teaches people about plants and animals, so she’s not a programmer. However, she co-authored the first-ever R textbook published in Russian, which makes her experience unique. Typically, I work with people who are programmers or data scientists, but she’s out there in the field, literally working with marine life.
 
-![](unnamed4.jpg)
+![](unnamed4.jpg){fig-alt="Second speaker - Adi Sarid, CEO of Sarid Institute LTD, a data science company focusing on production and consumption"}
 
 Our second speaker was [Adi Sarid](https://www.linkedin.com/in/adi-sarid/?originalSubdomain=il), the CEO of [Sarid Institute LTD](https://sarid-ins.com/), a data science company focusing on production and consumption. He’s also writing a book on R, this time in Hebrew. It’s a completely different experience—he’s a business leader working with governments and large firms, and he showcased some fantastic examples of practical applications in his talk.
 

--- a/posts/collaborative-growth-the-botswana-r-user-group-and-regional-partnerships/index.qmd
+++ b/posts/collaborative-growth-the-botswana-r-user-group-and-regional-partnerships/index.qmd
@@ -19,7 +19,7 @@ _The Botswana R User Group is seeking speakers for their upcoming online events.
 
 
 
-![](media.png)
+![](media.png){fig-alt="Edson Kambeu, founder and organizer of the Botswana R User Group"}
 
 
 **Please share about your background and involvement with the RUGS group.**
@@ -44,7 +44,7 @@ Our meetup group had about 100 members when we last talked to you. We now have a
 
 
 
-![](media%20(1).png)
+![](media%20(1).png){fig-alt="Participants attending an online meetup hosted by Botswana R users in collaboration with Estwatini R Users and Bulawayo R"}
 _Participants attending an online meetup hosted by Botswana R users in collaboration with [Estwatini R Users](https://www.meetup.com/eswatiniuser/) and [Bulawayo R](https://www.meetup.com/bulawayo-r-user-group/)_
 
 We are, however, still committed to growing the local community. We want to see more local participation in our meetup group. Last year, we collaborated with [R Ladies Gaborone](https://www.r-consortium.org/blog/2023/11/21/from-local-roots-to-global-reach-the-collaborative-expansion-of-r-ladies-gaborone) to organize an introduction to R workshop to increase our local membership. We are pleased to announce that this year, we plan to hold another workshop as a pre-conference event in the upcoming Botswana Deep Learning Indaba conference in July 2024. This workshop will help us to increase our local membership further and create more awareness about our group.
@@ -53,7 +53,7 @@ We are, however, still committed to growing the local community. We want to see 
 
 
 
-![](media%20(2).png)
+![](media%20(2).png){fig-alt="Participants at the Introduction to R Workshop held in collaboration between Botswana R users and R Ladies Gaborone"}
 _Participant at the Introduction to R Workshop held in collaboration between Botswana R users and R Ladies Gaborone_
 
 We value collaborations with our partner R User meetup groups in Southern Africa. In recent years, we have had regular meetups involving collaborative efforts with the [Bulawayo R User Group](https://www.meetup.com/bulawayo-r-user-group/) from Zimbabwe, the [Eswatini R User Group](https://www.r-consortium.org/blog/2022/02/28/eswatini-r-users-group-forging-ahead-despite-pandemic-hurdles) from Swaziland, and the [Namibia R User Group](https://www.r-consortium.org/blog/2022/08/09/fostering-the-budding-r-community-in-namibia) from Namibia. We have established a routine of holding joint meetups almost every two months, depending on the availability of speakers. The idea is to grow our communities by increasing the frequency of activities. 
@@ -62,7 +62,7 @@ We value collaborations with our partner R User meetup groups in Southern Africa
 
 
 
-![](media%20(3).png)
+![](media%20(3).png){fig-alt="Vebash Naidoo of RLadies Jozi presenting in an online meetup for Botswana R User"}
 _[Vebash Naidoo](https://www.linkedin.com/in/vebashini-naidoo-4260a96a/?originalSubdomain=za) of RLadies Jozi presenting in an online meetup for Botswana R Users_
 
 **You have a Meetup titled “[GIS and Creating Dashboards in R. A case study of conflicts events in Kenya](https://www.meetup.com/botswana-r-users/events/298287992/),” can you share more on the topic covered? Why this topic?**

--- a/posts/connecting-nebraska-through-r-jeffrey-stevens-journey-of-community-building/index.qmd
+++ b/posts/connecting-nebraska-through-r-jeffrey-stevens-journey-of-community-building/index.qmd
@@ -7,7 +7,7 @@ date: "02/06/2025"
 url: "https://r-consortium.org/posts/connecting-nebraska-through-r-jeffrey-stevens-journey-of-community-building/"
 unpublished: false
 categories: ["rugs", "events", "north america"]
-image-alt: "Connecting Nebraska Through R: Jeffrey Stevens’ Journey of Community Building"
+image-alt: "Nebraska R User Group logo"
 
 ---
 
@@ -57,7 +57,7 @@ All attendees at the kickoff meeting were from academia or involved in nonprofit
 
 I highlighted this topic in my email, emphasizing the desire for industry partners to participate and share their insights. The academic participants are significantly interested in how to transition to industry positions, an area I feel more comfortable discussing.
 
-![](NebRUGCollinBerke.png){fig-alt="Nebraska RUG Collin Berke"}
+![](NebRUGCollinBerke.png){fig-alt="Nebraska R User Group Kickoff Meeting, Collin Berke presenting"}
 Nebraska R User Group Kickoff Meeting: [Collin Berke](https://www.collinberke.com/)
 
 
@@ -66,7 +66,7 @@ Nebraska R User Group Kickoff Meeting: [Collin Berke](https://www.collinberke.co
 
 The kickoff meeting was fantastic. As I mentioned last year, the original group consisted of about five or six people from the university. Typically, only four of us met each month, which was relatively small. However, we had 20 people in attendance for the kickoff meeting, which was great! It was mostly folks from Lincoln; unfortunately, no one from Omaha could make it since the meeting was in person.
 
-![](NebRUGRachelRogers.png){fig-alt="Nebraska RUG Rachel Rogers"}
+![](NebRUGRachelRogers.png){fig-alt="Nebraska R User Group Kickoff Meeting, Rachel Rogers presenting"}
 Nebraska R User Group Kickoff Meeting: [Rachel Rogers](https://www.linkedin.com/in/rachelesrogers/)
 
 I was excited about the turnout, mainly because most attendees were academics I already knew. Still, I also met a few new people from the university. Additionally, we had representatives from [Nebraska Public Media](https://nebraskapublicmedia.org/en/watch/live/?gad_source=1\&gclid=Cj0KCQiAqL28BhCrARIsACYJvkc0RJUmqAJrWTGT1J6o9P0anRam3rJyxk4FKHEJHotsnaxDMe_AClUaApW9EALw_wcB) and [Nebraska Game and Parks](https://members.grownebraska.org/list/member/nebraska-game-and-parks-164?utm_source=google\&gad_source=1\&gclid=Cj0KCQiAqL28BhCrARIsACYJvkdMY_i--W_KWOLTzLpze8Izpcet2qEWRrFwRpTk0UPC00QdMMI9Nd4aAkCIEALw_wcB), which was exciting because it included some nonprofit and governmental groups. 
@@ -77,7 +77,7 @@ My main goal for the kickoff meeting was facilitating communication among the at
 
 We included a couple of lightning talks in the agenda. These were short, five-minute presentations showcasing the various projects participants had been working on. The aim was to help everyone build connections and gain insight into their peers' work. 
 
-![](NebRUGParticipants.png){fig-alt="Nebraska RUG participants"}
+![](NebRUGParticipants.png){fig-alt="Nebraska R User Group Kickoff Meeting, smiling participants"}
 Nebraska R User Group Kickoff Meeting: Participants
 
 

--- a/posts/contributing-to-base-r-with-coding-equity-and-joy-inside-the-r-contributors-project/index.qmd
+++ b/posts/contributing-to-base-r-with-coding-equity-and-joy-inside-the-r-contributors-project/index.qmd
@@ -5,14 +5,14 @@ description: "Ella Kaye, Research Software Engineer at the University of Warwick
 author: "R Consortium"
 categories: ["rugs", "lgbtq+", "software development", "women in tech"]
 image: "RSprint.png"
-image-alt: "Making contributing to base R more accessible and inclusive"
+image-alt: "Participants from the R Project Sprint, University of Warwick, 2023"
 date: "01/13/2026"
 url: "https://r-consortium.org/posts/contributing-to-base-r-with-coding-equity-and-joy-inside-the-r-contributors-project/"
 
 ---
 [Ella Kaye](https://www.linkedin.com/in/ellakaye/?originalSubdomain=uk), Senior Research Software Engineer at the University of Warwick and one of the organizers of the [R Contributors project](https://contributor.r-project.org/) (also on [Meetup](https://www.meetup.com/r-contributors/)), recently spoke with the R Consortium about her path into the R community and her efforts to make contributing to base R more accessible and inclusive. She shared insights from organizing R Developer Days, using GitHub to lower barriers for new contributors, learning with joy while developing the R package `aperol`, and fostering community with rainbowR.
 
-![](EllaKaye.png){width=50%}
+![](EllaKaye.png){width=50% fig-alt="Ella Kaye, Senior Research Software Engineer at the University of Warwick and one of the organizers of the R Contributors project"}
 
 ## Please share about your background and involvement with the RUGS group.
 
@@ -24,7 +24,7 @@ At Warwick, I’m on the committee of the [Warwick R User Group](https://warwick
 
 We organize [R Developer Days](https://contributor.r-project.org/events/r-dev-days/), which bring together a wide range of contributors, from members of R Core to those who’ve never contributed to base R before. In 2023, we held a three-day [R Sprint](https://contributor.r-project.org/r-project-sprint-2023/) at Warwick. Participants came from all over the world and represented various groups within the R community and the broader R world. It was a fantastic experience that led to several patches in the R codebase. We also run monthly R contributor [office hours](https://contributor.r-project.org/events/office-hours/) and a [C Study Group for R contributors](https://contributor.r-project.org/events/c-study-group-2025/).
 
-![](RSprint.png)
+![](RSprint.png){fig-alt="Participants from the R Project Sprint, University of Warwick, 2023"}
 
 _R Project Sprint, University of Warwick, 2023_
 
@@ -36,7 +36,7 @@ At the R Dev Days, we’re doing something a bit different and more specific tha
 
 Success hinges on identifying suitable bugs to work on, as many listed on [Bugzilla](https://www.bugzilla.org/) may exceed the technical capabilities of the participants or require buy-in from R Core members. A lot of work goes into reviewing bugs on Bugzilla beforehand to select those that are suitable for a Dev Day, ensuring they cater to varying levels of experience and technical skills. 
 
-![](RDevDay.png)
+![](RDevDay.png){fig-alt="R Contributors at R Dev Day @ PLUS 2024"}
 
 _R Contributors at R Dev Day @ PLUS 2024_
 

--- a/posts/crops-code-and-community-build-r-mob-user-group-in-australia/index.qmd
+++ b/posts/crops-code-and-community-build-r-mob-user-group-in-australia/index.qmd
@@ -6,13 +6,13 @@ description: "Dr. Asad (Md) Asaduzzaman, organizer of R-Mob, the R user group at
 categories: ["rugs", "software development", "environment"]
 author: "R Consortium"
 image: "RMobLogo.png"
-image-alt: "picture of R-Mob group logo"
+image-alt: "Logo for R-Mob, the R user group at Charles Sturt University (CSU), Australia"
 date: "01/12/2026"
 ---
 
 [Dr. Asad (Md) Asaduzzaman](https://www.linkedin.com/in/asad07/?originalSubdomain=au), organizer of [R-Mob](https://www.meetup.com/meetup-group-ckhmlaoy/), the R user group at Charles Sturt University (CSU), Australia, recently spoke with the R Consortium about strengthening R capacity in agricultural and environmental research through community-driven learning. He shared how R-Mob brings together researchers and students to apply R to real-world agronomic and ecological challenges. Dr. Asad discussed integrating R into agricultural education, building inclusive R communities, and using statistical modeling and machine learning to support data-driven decision-making in modern agriculture.
 
-![](DrAsadAsaduzzaman.png){width=50%}
+![](DrAsadAsaduzzaman.png){width=50% fig-alt="Dr. Asad (Md) Asaduzzaman, organizer of R-Mob, the R user group at Charles Sturt University (CSU), Australia"}
 
 ## Please share about your background and involvement with the RUGS group.
 
@@ -30,7 +30,7 @@ I have advanced proficiency in R, especially in statistical modeling, visualizat
 
 ## Can you share what the R community is like in Australia?
 
-![](RMobLogo.png){width=50%}
+![](RMobLogo.png){width=50% fig-alt="Logo for R-Mob, the R user group at Charles Sturt University (CSU), Australia"}
 
 The R community in Australia is highly active, diverse, and collaborative, encompassing academia, government, industry, and the private tech sector. Researchers and professionals in fields such as agriculture, ecology, health, economics, and IT increasingly rely on R due to its open-source nature, strong community support, and rapid innovation through various packages.
 

--- a/posts/data-engineering-scientific-applications-and-ai-inside-r-user-group-philippines-growth/index.qmd
+++ b/posts/data-engineering-scientific-applications-and-ai-inside-r-user-group-philippines-growth/index.qmd
@@ -7,7 +7,7 @@ date: "04/24/2025"
 url: "https://r-consortium.org/posts/data-engineering-scientific-applications-and-ai-inside-r-user-group-philippines-growth/"
 unpublished: false
 categories: ["rugs", "events", "ai", "asia"]
-image-alt: "Data Engineering, Scientific Applications and AI - Inside R User Group Philippines’ Growth"
+image-alt: "Smiling participants from RUG-PH 11th Anniversary Celebration 14th August 2024"
 
 ---
 
@@ -15,7 +15,7 @@ image-alt: "Data Engineering, Scientific Applications and AI - Inside R User Gro
 
 
 
-![](RUG-PHAnniversary.png)
+![](RUG-PHAnniversary.png){fig-alt="Smiling participants from RUG-PH 11th Anniversary Celebration 14th August 2024"}
 
 _RUG-PH 11th Anniversary Celebration 14th August 2024_
 
@@ -79,7 +79,7 @@ We believe it’s essential to be reliable and consistent for our members. Even 
 
 **Who are some key collaborators and supporters that help keep the R User Group Philippines running smoothly?**
 
-![](RUG-PH-Organizers.png)
+![](RUG-PH-Organizers.png){fig-alt="RUG PH organizers Joma Miñoza, Joe Brillantes, Michelle Alarcon, and Rad Basa"}
 
 _Left to Right, Joma Miñoza, Joe Brillantes, Michelle Alarcon, and Rad Basa_
 
@@ -92,7 +92,7 @@ We also utilize other connections. For instance, I often contact [Joma Miñoza](
 
 Rad Basa is a software engineer who works for [Appsilon](https://www.appsilon.com/). When we discuss software engineering practices, I typically consult him. We are also good friends with [Data Engineering Pilipinas](https://dataengineering.ph/). The founder of that group, [Myk Ogbinar](https://www.linkedin.com/in/ogbinar/?originalSubdomain=hk), is very supportive and assists me when I need help finding speakers for events. 
 
-![](MykOgbinar.png){width=50%}
+![](MykOgbinar.png){width=50% fig-alt="Data Engineering Pilipinas founder Myk Ogbinar"}
 
 _Myk Ogbinar_
 

--- a/posts/decade-of-data-celebrating-10-years-of-innovation-at-the-new-york-r-conference/index.qmd
+++ b/posts/decade-of-data-celebrating-10-years-of-innovation-at-the-new-york-r-conference/index.qmd
@@ -7,10 +7,10 @@ url: "https://r-consortium.org/posts/decade-of-data-celebrating-10-years-of-inno
 unpublished: false
 categories: ["events", "ai", "north america"]
 image: "NYR10_Email_rstats_Banner.png"
-image-alt: "Decade of Data: Celebrating 10 Years of Innovation at the New York R Conference"
+image-alt: "NYR10 2024 conference banner — Decade of Data: Celebrating 10 Years of Innovation at the New York R Conference"
 
 ---
-![](NYR10_Email_rstats_Banner.png)
+![](NYR10_Email_rstats_Banner.png){fig-alt="NYR10 2024 conference banner — Decade of Data: Celebrating 10 Years of Innovation at the New York R Conference"}
 
 Come celebrate 10 YEARS of the [**New York R Conference**](http://rstats.ai/nyr?utm_source=nyhackr)! This year’s conference takes place **May 16th & 17th with workshops May 15th**. We are taking a trip down memory lane and looking back over the past nine years. Come listen to some of the all-time greats who will be gracing our stage once again, and we’re also adding some fresh and exciting new voices to the mix!
 


### PR DESCRIPTION
## Summary
- Applies 32 reviewed CSV rows (status `Accepted`) across 13 blog posts
- Includes previously flagged "Needs work" rows (F0009, F0033, F0052–F0053, F0056, F0059, F0065–F0068, F0079–F0082) and new rows F0102–F0114
- Re-edits rows where alt text was updated after batch 1 (F0061 YuYongPoh, F0095–F0097 Nebraska RUG meetup photos, F0092 hero `image-alt`)

## Row 116 (F0115) — demystifying-llms-with-ellmer
**Not included** — still `pending` in CSV. The post body only embeds a YouTube video (`{{< video ... >}}`); no markdown image needs `{fig-alt}`. The YAML `image:` thumbnail is used for social/listing cards and already has `image-alt` set. The PNG file is not present in the post directory (likely only used when published).

## Test plan
- [ ] GitHub Pages build completes (no duplicate YAML `image-alt` keys)
- [ ] Spot-check re-edited Nebraska and Malaysia RUG images
- [ ] Verify 650K-for-R and NYR conference posts render with alt attributes