### PR TITLE
Add accessible alt text to blog posts (batch 4)

### DIFF
--- a/posts/empowering-government-professionals-in-nepal-using-r-programming-for-forestry-data-analysis/index.qmd
+++ b/posts/empowering-government-professionals-in-nepal-using-r-programming-for-forestry-data-analysis/index.qmd
@@ -6,10 +6,8 @@ description: "In a seven-day program run by the Forest Research and Training Cen
 categories: ["rugs", "asia", "environment"]
 author: "Prakash Lamichhane, Research Officer at Ministry of Forests and Environment, Nepal"
 image: "data-forestry-analysis-group.png"
-image-alt: "picture from EnviroDataR Group Nepal on meetup.com"
-date: "12/17/2025"
----
-
+image-alt: "Empowering Government Professionals in Nepal Using R programming for Forestry Data Analysis"
+date: "12/17/2025"---
 The R Consortium supports the global community of users, maintainers, and developers of R, a fast-growing language for statistical computing and graphics. In a world where data is increasingly at the heart of evidence-based decision-making, the R language is empowering professionals in new and inspiring ways. A recent capacity-building initiative in Nepal, organized by the joint effort of Forest Research and Training Center, Koshi Province and [EnviroDataR Group Nepal](https://www.meetup.com/enirodatar-group-nepal/), exemplifies this transformation, showcasing how R is becoming an essential tool for sustainable forest management.
 
 ## **The Challenge: Turning Data into Decisions**

--- a/posts/empowering-the-R-Community-Insights-from-Myles-Mitchell-of-the-Leeds-Data-Science-Group/index.qmd
+++ b/posts/empowering-the-R-Community-Insights-from-Myles-Mitchell-of-the-Leeds-Data-Science-Group/index.qmd
@@ -7,13 +7,11 @@ url: "https://r-consortium.org/posts/empowering-the-R-Community-Insights-from-My
 unpublished: false
 categories: ["submissions", "pharma", "rugs", "events", "ai"]
 image: "image_1.jpg"
-image-alt: "Empowering the R Community: Insights from Myles Mitchell of the Leeds Data Science Group"
-
+image-alt: "Myles Mitchell, co-organizer of the Leeds Data Science group"
 ---
-
 The R Consortium recently interviewed [Myles Mitchell](https://www.linkedin.com/in/myles-mitchell-4009aa98/?originalSubdomain=uk), co-organizer of the [Leeds Data Science group](https://www.meetup.com/leeds-data-science-meetup/), to discuss the local R community and the group’s recent activities. Myles highlighted the group’s efforts to create an inclusive and welcoming environment for all participants. The group is dedicated to creating networking opportunities for students interested in pursuing a career in data science and sharing job openings.\
 \
-![](image_1.jpg)
+![](image_1.jpg){fig-alt="Myles Mitchell, co-organizer of the Leeds Data Science group"}
 
 The Leeds Data Science group is hosting an in-person event titled “[***Improving the Fidelity and Stability of Large Language Models***](https://www.meetup.com/leeds-data-science-meetup/events/300758737/)” on the 23rd of July. 
 
@@ -25,7 +23,7 @@ At Jumping Rivers, we receive funding from the R Consortium. We organize the [Le
 
 **Can you share what the local R Community is like?**
 
-![](image_2.jpg)
+![](image_2.jpg){fig-alt="Leeds Data Science building"}
 
 I am located in Newcastle, in the northeast of England, where a large community is keenly interested in data science. Our community includes [Newcastle University](https://www.ncl.ac.uk/) and [Northumbria University](https://www.northumbria.ac.uk/) students, many of whom are studying data science or statistics. There are also professionals from various industries looking for data science jobs. Our meetups are attended by prospective data scientists and students eager to network and learn more about the field.
 
@@ -43,7 +41,7 @@ During our Meetup on “Improving the Fidelity and Stability of Large Language M
 
 Regarding techniques, I’m currently reviewing how we organize our meetups. Our meetups are free to attend for all participants, and we aim to create a welcoming and accessible environment for everyone to network and meet like-minded individuals in the area. The meetups are held every two to three months on weekdays in the evenings, providing attendees with time to travel from their place of work to the venue. We offer refreshments at the start, including pizza and soft drinks, and we ensure that vegan, gluten-free, and halal options are included to cater to a wide range of dietary preferences. 
 
-![](image_3.jpg)
+![](image_3.jpg){fig-alt="Image of presenter at Leeds Data Science Group meetup"}
 
 We often run interactive workshops at the North East Data Science Meetups, including a recent [meetup](https://www.meetup.com/newcastle-upon-tyne-data-science-meetup/events/300470386/) on the Apache Arrow interface for R, led by [Nic Crane](https://thisisnic.github.io/about/) on July 18th. To make our workshops as inclusive as possible, we provide attendees with all necessary materials and dependencies via a cloud environment created using [Posit Workbench](https://docs.posit.co/pwb/). It allows participants without prior installation of RStudio IDE to contribute and interact with the workshop materials. Our goal is to make our workshops accessible to a broad audience, including those from non-R backgrounds. In general, we aim to create an event where attendees can participate without the burden of installing multiple packages or downloading data.
 

--- a/posts/endophytes-oaks-and-r-how-r-ladies-morelia-is-cultivating-science-and-community-in-morelia-mexico/index.qmd
+++ b/posts/endophytes-oaks-and-r-how-r-ladies-morelia-is-cultivating-science-and-community-in-morelia-mexico/index.qmd
@@ -8,10 +8,8 @@ date: "10/18/2024"
 url: "https://r-consortium.org/posts/endophytes-oaks-and-r-how-r-ladies-morelia-is-cultivating-science-and-community-in-morelia-mexico/"
 unpublished: false
 categories: ["rugs", "events", "ai", "south america", "women in tech"]
-image-alt: "Endophytes, Oaks, and R: How R-Ladies Morelia is Cultivating Science and Community in Morelia, Mexico"
-
+image-alt: "Members of R-Ladies Morelia"
 ---
-
 [Goretty Mendoza](https://www.linkedin.com/in/goretty-mendoza-785004322/), the organizer of the 
 [R-Ladies Morelia](https://www.meetup.com/es-ES/rladies-morelia/), recently spoke to the R Consortium about her experience 
 with the group and her work using R in molecular biology. Under her guidance, the group has grown into a supportive 
@@ -20,7 +18,7 @@ Goretty is committed to empowering the local R community through online and phys
 and networking. 
 
 
-![](Goretty.png){width=50%}
+![](Goretty.png){width=50% fig-alt="Goretty Mendoza, organizer of the R-Ladies Morelia"}
 
 
 ***Please share about your background and involvement with the RUGS group.***
@@ -36,7 +34,7 @@ who live in other cities, thanks to the R Consortium’s grant. I'm sure we retu
 aim to improve our R skills.
 
 
-![](RLadiesMorelia.png)
+![](RLadiesMorelia.png){fig-alt="Members of R-Ladies Morelia"}
 
 
 **Can you share what the local R community is like? **
@@ -49,7 +47,7 @@ experience in R share their knowledge with new members who are just starting. It
 can learn and grow together. Our R-community is a great opportunity to get involved, collaborate with other women, 
 and make new friends as we learn. 
 
-![](r-ladies-morelia-zoom.png)
+![](r-ladies-morelia-zoom.png){fig-alt="Many faces from R-Ladies Morelia online Zoom meeting"}
 
 
 **Please share about a project you are working on or have worked on using the R language. What is the goal/reason, result, 

--- a/posts/enhancing-r-the-vision-and-impact-of-jan-viteks-maintainr-initiative/index.qmd
+++ b/posts/enhancing-r-the-vision-and-impact-of-jan-viteks-maintainr-initiative/index.qmd
@@ -7,11 +7,9 @@ date: "05/15/2024"
 url: "https://r-consortium.org/posts/enhancing-r-the-vision-and-impact-of-jan-viteks-maintainr-initiative/"
 unpublished: false
 categories: ["isc", "announcements", "events", "ai", "infrastructure"]
-image-alt: "Enhancing R: The Vision and Impact of Jan Vitek’s MaintainR Initiative"
-
+image-alt: "Jan Vitek, a professor at Northeastern University’s Khoury College of Computer Sciences"
 ---
-
-![](Untitled.jpg)
+![](Untitled.jpg){fig-alt="Jan Vitek, a professor at Northeastern University’s Khoury College of Computer Sciences"}
 
 
 The R Consortium recently interviewed [Jan Vitek](http://janvitek.org/), a professor at Northeastern University’s Khoury College of Computer Sciences. He specializes in programming languages, compilers, and systems. Notably, he developed one of the first real-time Java virtual machines in collaboration with Boeing, which involved writing the navigation software of a [ScanEagle UAV](https://www.cs.purdue.edu/news/articles/2006/researchers-scaneagle.html) in Java and demonstrating that it out-performed the legacy version of the system written in C++. Vitek is actively involved in the programming language community and has held multiple leadership roles, including chairing [SIGPLAN](https://www.sigplan.org/). In his spare time Vitek is a cinephile with a presence on [Letterboxd](https://letterboxd.com/janvite/) and is the human of a dog named [Olaf](https://www.instagram.com/olaf.pix/).

--- a/posts/expanded-fda-ectd-file-format-support-for-r-packages/index.qmd
+++ b/posts/expanded-fda-ectd-file-format-support-for-r-packages/index.qmd
@@ -7,11 +7,9 @@ author: "R Consortium"
 categories: ["submissions", "pharma", "announcements", "working groups"]
 image: "fda-logo-main-image.png"
 date: "12/08/2025"
-image-alt: "Expanded FDA eCTD File Format Support for R Packages — A Milestone Achieved Through Industry–FDA Collaboration"
-
+image-alt: "US FDA logo"
 ---
-
-![](fda-logo.jpg)
+![](fda-logo.jpg){fig-alt="US FDA logo"}
 
 ::: {.callout-note}
 ## Update (December 10, 2025)

--- a/posts/expanding-the-reach-of-r-across-clevelands-data-and-tech-community/index.qmd
+++ b/posts/expanding-the-reach-of-r-across-clevelands-data-and-tech-community/index.qmd
@@ -12,7 +12,7 @@ date: "11/24/2025"
 
 [Alec Wong](https://www.linkedin.com/in/alec-wong-67966242/), organizer of the [Cleveland R Users Group](https://www.meetup.com/cleveland-user-group/), recently spoke with the R Consortium about energizing the local R community and supporting data professionals in a rapidly changing job market. With a focus on inclusive learning and real-world applications, Alec and his co-organizers are creating events that connect students, analysts, and industry experts alike. Their recent “Career Planning” session brought together data scientists, hiring managers, and job seekers for an open conversation about navigating AI-driven changes in the workforce. Alec also shared how the group is expanding its reach through collaborations with other tech meetups and participation in Cleveland’s Best of Tech event.
 
-![](AlecWong.png){width=50%}
+![](AlecWong.png){width=50% fig-alt="Alec Wong, organizer of the Cleveland R Users Group"}
 
 ## Please share your background and involvement with the RUGS group.
 

--- a/posts/exploring-geometa-an-r-package-for-managing-geographic-metadata/index.qmd
+++ b/posts/exploring-geometa-an-r-package-for-managing-geographic-metadata/index.qmd
@@ -7,17 +7,15 @@ date: "03/20/2025"
 url: "https://r-consortium.org/posts/exploring-geometa-an-r-package-for-managing-geographic-metadata/"
 unpublished: false
 categories: ["isc", "announcements", "submissions", "pharma", "infrastructure"]
-image-alt: "Exploring geometa: An R Package for Managing Geographic Metadata"
-
+image-alt: "Emmanuel Blondel, author of geometa, ows4R, geosapi, geonapi and geoflow—key R packages for geospatial data management"
 ---
-
 **geometa** provides an essential object-oriented data model in R, enabling users to efficiently manage geographic metadata. The package facilitates handling of ISO and OGC standard geographic metadata and their dissemination on the web, ensuring that spatial data and maps are available in an open, internationally recognized format. As a widely adopted tool within the geospatial community, geometa plays a crucial role in standardizing metadata workflows.
 
 Since 2018, the R Consortium has supported the development of geometa, recognizing its value in bridging metadata standards with R’s data science ecosystem. You can try geometa yourself here: [CRAN – geometa](https://cran.r-project.org/package=geometa).
 
 In this interview, we speak with Emmanuel Blondel, the author of geometa, ows4R, geosapi, geonapi and geoflow—key R packages for geospatial data management. With a background in Agronomic Sciences and Environmental & Natural Resources Management from the French National Polytechnical Institute (INP-ENSAT), Emmanuel specializes in Geographic Information Systems (GIS) applied to fields such as agronomy, environment, fisheries, and aquatic sciences. As an active open-source developer, he shares insights into the evolution of geometa, the challenges of metadata standardization, and the future of geospatial data management in R.
 
-![](emmanuel.png)
+![](emmanuel.png){fig-alt="Emmanuel Blondel, the author of geometa, ows4R, geosapi, geonapi and geoflow—key R packages for geospatial data management"}
 
 ## What is the significance of geometa including support for ISO 19115-3 getting published on CRAN? Is this about incorporating new standards?
 

--- a/posts/exploring-kuzco-making-computer-vision-for-r-easily-accessible/index.qmd
+++ b/posts/exploring-kuzco-making-computer-vision-for-r-easily-accessible/index.qmd
@@ -14,7 +14,7 @@ date: "05/22/2025"
 
 In this interview, we explore the ideas behind `{kuzco}`, its use of LLMs, and how it differs from conventional deep learning frameworks like `{keras}` and `{torch}` in R. `{kuzco}` is open source and Frank states in the interview that the project is actively looking for contributions, both technical and non-technical. Feel free to contact him directly (frankiethull@proton.me for open source connections) to ask questions and find out more.
 
-![](frankthull.png){width=60%}
+![](frankthull.png){width=60% fig-alt="Frank Hull, data scientist, open source contributor, and developer of {kuzco}, an R package for image classification and computer vision using large language models (LLMs)"}
 
 
 ## 1. What problem does {kuzco} solve that existing R tools like {keras} or {torch} don’t?

--- a/posts/free-boba-tea-and-technical-r-topics-lure-young-learners-to-new-brunei-r-user-group/index.qmd
+++ b/posts/free-boba-tea-and-technical-r-topics-lure-young-learners-to-new-brunei-r-user-group/index.qmd
@@ -5,14 +5,12 @@ aliases:
 description: "The R community in Brunei may be small, but it is growing thanks to the efforts of the Brunei R User Group."
 author: "R Consortium"
 image: "smiles.jpg"
-image-alt: "Brunei R User Group Meeting"
+image-alt: "Brunei R User Group participants selfie"
 date: "09/20/2024"
 url: "https://r-consortium.org/posts/free-boba-tea-and-technical-r-topics-lure-young-learners-to-new-brunei-r-user-group/"
 unpublished: false
 categories: ["rugs", "events", "asia"]
-
 ---
-
 [Haziq Jamil](https://www.linkedin.com/in/haziqjamil/), the founder and organizer of 
 the [Brunei R User Group](https://www.meetup.com/bruneir/), recently spoke with the 
 R Consortium. Haziq established the first R User Group in Brunei to promote R programming 
@@ -21,8 +19,7 @@ monthly meetups and events to advance R skills across various sectors in Brunei.
 Through these efforts, Haziq aims to build a supportive and inclusive R community, 
 encouraging both personal growth and data-driven innovation in the region.
 
-![](haziq-jamil.jpg){fig-alt="Haziq Jamil Assistant Professor in Statistics at Universiti 
-Brunei Darussalam"}
+![](haziq-jamil.jpg){fig-alt="Haziq Jamil, founder and organizer of Brunei R User Group, Assistant Professor in Statistics at Universiti Brunei Darussalam"}
 
 **Please share your background and involvement with the RUGS group.**
 
@@ -36,7 +33,7 @@ and strategy, and ensure that its initiatives align with its mission of promotin
 programming and fostering a supportive learning environment, focusing on community 
 engagement and collaboration.
 
-![](smiles.jpg){fig-alt="Brunei R User Group members"}
+![](smiles.jpg){fig-alt="Brunei R User Group participants selfie"}
 
 **Can you share what the R community is like in Brunei? **
 
@@ -57,7 +54,7 @@ local R community.
 **You hosted a Meetup, “[R>aya with R](https://www.meetup.com/bruneir/events/300000854/?eventOrigin=group_events_list),” 
 in April. Can you share more about the topic? Why this topic? **
 
-![](brunei-raya-meetup.jpg){fig-alt="Brunei R User Group Raya Meetup"}
+![](brunei-raya-meetup.jpg){fig-alt="Brunei R User Group Raya Meetup 2024-04-27"}
 
 The R User Group’s "[R>aya with R](https://bruneir.github.io/posts/bru-2/)" Meetup in 
 Brunei was a lively event that combined Hari Raya Aidilfitri’s (Eid-ul-Fitr) festive 
@@ -65,7 +62,7 @@ spirit with the exploration of R programming. To engage younger audiences, we of
 free boba tea as a beverage during the session. The event featured informative sessions 
 led by expert community members, each focusing on advanced topics relevant to different fields.
 
-![](boba.jpg){fig-alt="Brunei R User Group Boba Tea"}
+![](boba.jpg){fig-alt="Free boba tea offered to engage younger audiences"}
 
 
 One of the critical presentations was on “Survival Analysis” 
@@ -74,7 +71,7 @@ explained statistical techniques to predict the time until an event of interest,
 guests’ arrival at a Hari Raya open house. This topic is directly related to fields 
 that depend on time-to-event data, such as healthcare or actuarial science.
 
-![](presentation.jpg){fig-alt="presentation Survival Analysis by Dr. Elvynna Leong"}
+![](presentation.jpg){fig-alt="Survival Analysis presentation by Dr. Elvynna Leong"}
 
 One of the highlights was [Wafid Sophian](https://www.linkedin.com/in/wafid-sophian-6b8073141/?originalSubdomain=bn)’s session 
 on “Simulation Methods for Economic Analysis.” In this presentation, Wafid demonstrated how R can be 

--- a/posts/from-the-adas-utils-package-to-r-trento-paolo-bosetti-on-building-tools-and-community/index.qmd
+++ b/posts/from-the-adas-utils-package-to-r-trento-paolo-bosetti-on-building-tools-and-community/index.qmd
@@ -6,13 +6,11 @@ description: "Paolo Bosetti discusses his path from creating the adas.utils pack
 categories: ["rugs","eu", "software development"]
 author: "R Consortium"
 image: "PaoloBosetti.png"
-image-alt: "picture of Paolo Bosetti, R-Trento User Group organizer"
-date: "11/25/2025"
----
-
+image-alt: "Dr Paolo Bosetti, founder of R-Trento User Group (R-TUG), and Associate Professor, University of Trento, Italy"
+date: "11/25/2025"---
 [Dr Paolo Bosetti](https://paolobosetti.quarto.pub/), Associate Professor at the University of Trento, Italy, recently spoke with the R Consortium about founding the [R-Trento User Group](https://www.meetup.com/r-trento-users-group/) (R-TUG) and fostering collaboration between academia, industry, and the public sector in Italy. He shared how he uses R in teaching industrial engineering students, from integrating RStudio and Quarto into coursework to emphasizing reproducible analysis and reporting. Dr. Paolo also discussed the development of his `adas.utils` package for experimental design, the importance of documenting community activities through a group blog, and his vision for expanding the R community in Trento.
 
-![](PaoloBosetti.png){width=50%}
+![](PaoloBosetti.png){width=50% fig-alt="Dr Paolo Bosetti, founder of R-Trento User Group (R-TUG), and Associate Professor, University of Trento, Italy"}
 
 ## Please share your background and involvement with the RUGS group.
 
@@ -24,7 +22,7 @@ Within my university, I have several colleagues across different departments—s
 
 We are using Meetup to gather users, and the group currently has around over 80 members. At our inaugural meeting, approximately 30 users participated, and we conducted a total of four presentations on various topics over the course of three hours in the afternoon.
 
-![](RUsersTrentoLogo.png){width=50%}
+![](RUsersTrentoLogo.png){width=50% fig-alt="R-Trento User Group (R-TUG) Logo"}
 
 ## Was your first meetup held in person or online? What format do you plan to use for future meetups?
 
@@ -32,7 +30,7 @@ The first meeting was held in person because we wanted to foster connections. Si
 
 For future meetings, we plan to implement a hybrid format. We will continue to meet in person while also recording the sessions on Zoom and providing a link for others to participate remotely. This way, we can maintain our in-person interactions while accommodating those who wish to join online.
 
-![](RUsersTrentoMeetup.png)
+![](RUsersTrentoMeetup.png){fig-alt="View of R-Trento User Group (R-TUG) meetup"}
 
 ## Can you share what the R community is like in Italy?
 
@@ -70,7 +68,7 @@ For example, I use `ggplot` for graphics, and functions have been designed to be
 
 In our blog, you can find an [introduction to the package](https://rtug.unitn.it/posts/004-adas.utils/), which is designed to facilitate the creation of target plans and fractional factorial plans, as well as to analyze the alias structure in fractional factorial designs. The package also features functionalities not commonly available in R, such as normal probability plots and Pareto charts, both of which are not standard in the Tidyverse.
 
-![](Normalprobabilityplot.png)
+![](Normalprobabilityplot.png){fig-alt="Normal probability plot using the {adas.utils} R package for experimental design"}
 
 
 ## How do I Build an R User Group?

--- a/posts/gergely-daroczis-journey-empowering-r-users-in-hungary/index.qmd
+++ b/posts/gergely-daroczis-journey-empowering-r-users-in-hungary/index.qmd
@@ -54,7 +54,7 @@ In 2013, I attended my first [useR! conference](https://www.r-project.org/confer
 
 
 
-![](Untitled%20(2).jpg){fig-alt="Budapest R User Group event with guest speakers including Hadley Wickham"}
+![](Untitled%20(2).jpg){fig-alt="Image of large Budapest Users of R Network audience"}
 
 
 In Hungary, the community’s growth began slowly, with only 20 to 30 members in the first few years. However, it gradually increased over time. The community also hosted some famous personalities such as [Romain Francois](https://www.linkedin.com/in/romain-francois/), Matt Dowle, and [Hadley Wickham](https://www.rstudio.com/authors/hadley-wickham/), which further accelerated its growth. Additionally, the community organized the [first satRday](https://budapest.satrdays.org/) and [second ERUM conference](https://2018.erum.io/), which provided a platform for networking and knowledge sharing, further strengthening the community.
@@ -63,7 +63,7 @@ In Hungary, the community’s growth began slowly, with only 20 to 30 members in
 
 
 
-![](Untitled%20(3).jpg){fig-alt="Budapest R User Group in-person meetup after COVID"}
+![](Untitled%20(3).jpg){fig-alt="Participants from eRum 2018, held in Budapest, Hungary, May 14-16, 2018"}
 
 
 **How has the group been doing since our last conversation?**
@@ -74,7 +74,7 @@ After COVID, restarting the meetups was very challenging. We didn’t organize a
 
 
 
-![](Untitled%20(4).jpg){fig-alt="Budapest R User Group bioinformatics lightning talks event"}
+![](Untitled%20(4).jpg){fig-alt="Image from presentation of '\"Full-Stack\" Data Science with R' delivered by Ajay Gopal, Chief Data Scientist at SelfScore, at Crunch 2018 in Budapest, Hungary"}
 
 
 Recently, we have been focusing on bioinformatics and I was introduced to a local company that offered help with reaching out to speakers. Speakers drive these community meetings by bringing in a topic for discussion and talk, which we continue to discuss later on. Our past few events have focused on life sciences and have followed a lightning talk format, where we had around five 15-minute talks at each event. The topics were diverse, covering life sciences, some with LLMs involved, others focused on highly advanced math for modeling. We also had shiny applications that showed the biodiversity of forests in Hungary and some open-source tools besides R. 
@@ -87,7 +87,7 @@ I can only offer subjective experiences on the matter, but I have witnessed the 
 
 
 
-![](Untitled%20(5).jpg){fig-alt="Budapest R User Group networking session with food and drinks"}
+![](Untitled%20(5).jpg){fig-alt="Budapest Users of R Network networking session with food and drinks"}
 
 
 It is important to have a room with plenty of chairs and a larger area for people to gather after the talks. We can provide soft drinks, beer, or wine along with some pizzas and have a chat for an hour or two after the talk. The venue is a crucial factor. It’s also important to have speakers who are interested in the community so that they will come to learn as well. It’s great to have speakers with interesting topics, but the most important thing for me is networking. After the talks, coming together and getting to know others, learning about their struggles, and maybe sharing some tips in person with each other, becoming friends, or learning about opportunities in other industries. Networking and facilitating connections are crucial tasks for R user group organizers.
@@ -104,7 +104,7 @@ I’m excited that COVID restrictions are easing up and meetups are returning to
 
 
 
-![](Untitled.png){fig-alt="Spare Cores cloud compute resources project related to R bindings"}
+![](Untitled.png){fig-alt="Logo for Spare Cores cloud compute resources project related to R bindings"}
 
 
 Currently, I’m focusing on the ETL pipeline of the [Spare Cores](https://sparecores.com/) project, collecting information on cloud compute resources, which will soon have the R bindings as well. In the past, I’ve been working on R packages related to reporting (e.g. “[pander](https://cran.r-project.org/web/packages/pander/index.html)”) and using R in production (e.g. “[logger](https://cran.r-project.org/web/packages/logger/index.html),” “[dbr](https://github.com/daroczig/dbr)” or “boto3”). Recently, I enjoyed integrating APIs and frameworks from other programming languages, such as Python (kudos to the [reticulate](https://rstudio.github.io/reticulate/) team!), in R.


### PR DESCRIPTION
## Summary
- Applies 34 reviewed CSV rows (F0598, F0155–F0182, F0185–F0189) across 11 blog posts
- Includes re-edits to previously Done Gergely Daróczi post images (rows 187–191 / F0185–F0189)
- Updates Nepal hero `image-alt`, Leeds/Morelia RUG posts, Jan Vitek, FDA eCTD, Cleveland, geometa, kuzco, Brunei RUG, R-Trento, and Budapest RUG images

## Safeguards
- Verified no duplicate YAML `image-alt` keys in modified posts
- Apply script updates existing `image-alt` line rather than adding a second key

## Test plan
- [ ] GitHub Pages build completes without YAML parse errors
- [ ] Spot-check Gergely Daróczi post re-edited alt text (F0185–F0189)
- [ ] Verify Brunei and R-Trento meetup images render with alt attributes