### PR TITLE
Fix YAML front matter closing delimiter on two blog posts.

### DIFF
--- a/posts/empowering-government-professionals-in-nepal-using-r-programming-for-forestry-data-analysis/index.qmd
+++ b/posts/empowering-government-professionals-in-nepal-using-r-programming-for-forestry-data-analysis/index.qmd
@@ -7,7 +7,9 @@ categories: ["rugs", "asia", "environment"]
 author: "Prakash Lamichhane, Research Officer at Ministry of Forests and Environment, Nepal"
 image: "data-forestry-analysis-group.png"
 image-alt: "Empowering Government Professionals in Nepal Using R programming for Forestry Data Analysis"
-date: "12/17/2025"---
+date: "12/17/2025"
+---
+
 The R Consortium supports the global community of users, maintainers, and developers of R, a fast-growing language for statistical computing and graphics. In a world where data is increasingly at the heart of evidence-based decision-making, the R language is empowering professionals in new and inspiring ways. A recent capacity-building initiative in Nepal, organized by the joint effort of Forest Research and Training Center, Koshi Province and [EnviroDataR Group Nepal](https://www.meetup.com/enirodatar-group-nepal/), exemplifies this transformation, showcasing how R is becoming an essential tool for sustainable forest management.
 
 ## **The Challenge: Turning Data into Decisions**

--- a/posts/from-the-adas-utils-package-to-r-trento-paolo-bosetti-on-building-tools-and-community/index.qmd
+++ b/posts/from-the-adas-utils-package-to-r-trento-paolo-bosetti-on-building-tools-and-community/index.qmd
@@ -7,7 +7,9 @@ categories: ["rugs","eu", "software development"]
 author: "R Consortium"
 image: "PaoloBosetti.png"
 image-alt: "Dr Paolo Bosetti, founder of R-Trento User Group (R-TUG), and Associate Professor, University of Trento, Italy"
-date: "11/25/2025"---
+date: "11/25/2025"
+---
+
 [Dr Paolo Bosetti](https://paolobosetti.quarto.pub/), Associate Professor at the University of Trento, Italy, recently spoke with the R Consortium about founding the [R-Trento User Group](https://www.meetup.com/r-trento-users-group/) (R-TUG) and fostering collaboration between academia, industry, and the public sector in Italy. He shared how he uses R in teaching industrial engineering students, from integrating RStudio and Quarto into coursework to emphasizing reproducible analysis and reporting. Dr. Paolo also discussed the development of his `adas.utils` package for experimental design, the importance of documenting community activities through a group blog, and his vision for expanding the R community in Trento.
 
 ![](PaoloBosetti.png){width=50% fig-alt="Dr Paolo Bosetti, founder of R-Trento User Group (R-TUG), and Associate Professor, University of Trento, Italy"}


### PR DESCRIPTION
The image-alt apply step merged the closing --- onto the date line, breaking Quarto render. Restore proper --- on its own line.