### PR TITLE
Add accessible alt text to blog posts (batch 5)

### DIFF
--- a/posts/growing-an-r-community-in-a-shifting-tech-landscape-the-story-of-rladies-zurich/index.qmd
+++ b/posts/growing-an-r-community-in-a-shifting-tech-landscape-the-story-of-rladies-zurich/index.qmd
@@ -6,13 +6,12 @@ description: "Luisa Barbanti, organizer of R-Ladies Zurich, shares how her team 
 author: "R Consortium"
 categories: ["rugs", "eu", "women in tech"]
 image: "RLadiesZurich.png"
-image-alt: "picture of R-Ladies Zurich organizers"
+image-alt: "R-Ladies Zurich organizers at the group’s second Anniversary"
 date: "12/09/2025"
 ---
-
 [Luisa Barbanti](https://www.linkedin.com/in/luisa-barbanti/?originalSubdomain=ch), organizer of [R-Ladies Zurich](https://www.meetup.com/rladies-zurich/), recently spoke with the R Consortium about building and sustaining a technically focused R community in Switzerland. With a background in biostatistics and professional experience at a data science consultancy, Luisa shared how she utilizes R for data wrangling, statistical modeling, and internal tooling, leveraging Quarto and Shiny. She discussed the evolution of R-Ladies Zurich and highlighted the challenges of maintaining momentum as community members transition through different phases of their careers.
 
-![](LuisaBarbanti.png){width=50%}
+![](LuisaBarbanti.png){width=50% fig-alt="Luisa Barbanti, organizer of R-Ladies Zurich"}
 
 ## Please share your background and involvement with the RUGS group.
 
@@ -24,7 +23,7 @@ My supervisor encouraged me to attend the [useR! conference](https://user2020.r-
 
 During the meeting, I recognized one of my acquaintances from Zurich, [Seraphina](https://www.linkedin.com/in/seraphina-kissling-625048197/), who had a master's in biostatistics. We struck up a conversation about how great the meeting was and wondered if there was an R-Ladies chapter in Zurich. To our surprise, we discovered there wasn't one. There were no active R-Ladies chapters in Switzerland at that time; some had been started but had unfortunately ceased their activities. 
 
-![](RLadiesZurichLogo.png)
+![](RLadiesZurichLogo.png){fig-alt="R-Ladies Zurich logo"}
 
 ## Can you share what the R community is like in Switzerland?
 
@@ -34,7 +33,7 @@ I feel that with the rise of machine learning and AI, the role of R in industry 
 
 In my current role at a consulting firm specializing in data science, we utilize R because we recognize its power and the extent to which it can be leveraged.
 
-![](RLadiesZurich.png)
+![](RLadiesZurich.png){fig-alt="R-Ladies Zurich organizers at the group’s second Anniversary"}
 
 R-Ladies Zurich Organizers at the group’s second Anniversary
 
@@ -48,7 +47,7 @@ Furthermore, we have an entire ecosystem of [Shiny](https://shiny.posit.co/) app
 
 While we are strong proponents of using R, this approach may be more of an exception than the norm. Nonetheless, R offers numerous capabilities that enable us to accomplish a wide range of tasks. Everything we do typically starts in RStudio, from which we work on various projects.
 
-![](RyssaMoffat.png)
+![](RyssaMoffat.png){fig-alt="Ryssa Moffat presenting"}
 
 ## How has the local community responded to your events, and what strategies have helped you grow participation?
 
@@ -62,7 +61,7 @@ As for our upcoming events, we currently don’t have any specific ones lined up
 
 Organizing these events requires considerable effort, and we’re currently facing a shortage of presenters. We do have one potential presenter in the pipeline, but the timeline remains uncertain. We have discussed collaborating with the Zurich R User Group to develop a workshop format for a larger audience, likely targeting the fall. Although we haven’t set a specific date yet, we anticipate being able to coordinate something after everyone returns from their summer vacations.
 
-![](R-LadiesZurichWomen'sDay.png)
+![](R-LadiesZurichWomen'sDay.png){fig-alt="R-Ladies Zurich Co-hosted Panel Discussion with the Zurich R User Group on International Women’s Day 2024"}
 
 R-Ladies Zurich Co-hosted Panel Discussion with the Zurich R User Group on International Women’s Day 2024
 

--- a/posts/health-technology-assessment-hta-working-group-kickoff-meeting/index.qmd
+++ b/posts/health-technology-assessment-hta-working-group-kickoff-meeting/index.qmd
@@ -7,23 +7,21 @@ date: "11/04/2024"
 url: "https://r-consortium.org/posts/health-technology-assessment-hta-working-group-kickoff-meeting/"
 unpublished: false
 categories: ["events", "working groups"]
-image-alt: "Health Technology Assessment (HTA) Working Group Kickoff: Building a Collaborative Vision in R for HTA"
-
+image-alt: "Slide showing Vision for the Working Group - Evolving policy landscape as a catalyst for a more unified approach to HTA analytics through R"
 ---
-
 On October 31, 2024, the Health Technology Assessment (HTA) Working Group convened for its first general meeting, marking the beginning of an exciting industry-wide initiative to elevate the role of R within the HTA community. The gathering featured 35 members, including co-chairs and founding members Gregory Chen, [Anders Gorst-Rasmussen](https://www.linkedin.com/in/anders-gorst-rasmussen-50bb732/?originalSubdomain=dk), [Dominic Muston](https://www.linkedin.com/in/dominic-muston-a897517/), and [Joseph Rickert](https://www.linkedin.com/in/joseph-rickert-a45a96?miniProfileUrn=urn%3Ali%3Afs_miniProfile%3AACoAAAAo_1UB1mlPH37Q6CKV1o0BVHibrVBgYsA&lipi=urn%3Ali%3Apage%3Ad_flagship3_search_srp_all%3B9Qho7amVQtCu8OfJFebhwA%3D%3D), with participants bringing varied expertise from across the HTA landscape. Hosted on video, the kickoff set the stage for collaboration, innovation, and tangible impacts on the development and application of R tools in health technology assessments.
 You can watch the recording [here.](https://zoom.us/rec/play/IGEvwwmmIZ_BVHB5wqMkdDpTcjC1VsEcEU4RcBJPkpZSR_zMOow3nCQH7FMTbiQk27bq0MBPABOgpHMe.LH2M4thN5AqgI3sY?canPlayFromShare=true&from=share_recording_detail&continueMode=true&componentName=rec-play&originRequestUrl=https%3A%2F%2Fzoom.us%2Frec%2Fshare%2F9NTj9ZtSKBFz3Ij0rf0x3gTSoOcx99MCdvJCzUEUz3XEboB-EhilI4mMQ-Bw8bYe.0IKFWabamQjvIRdS) 
 
 ## Opening Remarks and Vision
-![](OpeningRemarksandVision.png)
+![](OpeningRemarksandVision.png){fig-alt="Slide showing Vision for the Working Group - Evolving policy landscape as a catalyst for a more unified approach to HTA analytics through R"}
 Gregory Chen and Anders Gorst-Rasmussen opened the meeting with a vision of collaboration, emphasizing the importance of a shared, flexible structure within the HTA Working Group. The co-chairs highlighted two initial workstreams designed to channel the group’s efforts without restricting the scope of potential projects. This framework underscores the group’s commitment to evolve in response to member feedback and industry needs.
 
 ## Workstream 1: Building Connections Across the HTA Ecosystem
-![](Workstream1.png)
+![](Workstream1.png){fig-alt="Slide showing Workstream1 - Stakeholder and landscape mapping and opportunity assessment"}
 Anders Gorst-Rasmussen and Dominic Muston introduced the first workstream, focusing on building connections across diverse stakeholders within HTA. This foundational effort aims to foster a common perspective and identify relevant challenges and opportunities. By bridging gaps between different sectors within HTA, Workstream 1 seeks to create a solid framework for addressing complex issues in health technology evaluation and supporting innovation across the industry.
 
 ## Workstream 2: R Tools for HTA – Identification, Curation, and Education
-![](MappingofHTA.png)
+![](MappingofHTA.png){fig-alt="Slide showing Workstream2 - Mapping of HTA analytics related R packages"}
 Gregory Chen and Joseph Rickert presented Workstream 2, which takes a hands-on approach toward bolstering R’s role in HTA. Key goals include identifying relevant R packages, curating high-quality, production-ready tools, and proactively enhancing documentation and user resources. The working group will also promote these tools through blogs, webinars, and other educational efforts to foster a culture of learning and improvement around R for HTA.
 The ultimate aim is to ensure that the HTA community has access to well-documented, robust R tools and resources that meet industry needs.
 

--- a/posts/how-r-powers-cancer-research-and-community-teaching-in-austria/index.qmd
+++ b/posts/how-r-powers-cancer-research-and-community-teaching-in-austria/index.qmd
@@ -7,13 +7,11 @@ date: "08/20/2025"
 url: "https://r-consortium.org/posts/how-r-powers-cancer-research-and-community-teaching-in-austria/"
 unpublished: false
 categories: ["rugs", "events", "women in tech"]
-image-alt: "How R Powers Cancer Research and Community Teaching in Austria"
-
+image-alt: "Ekaterina Akimova-Höpner, founder of R-Ladies Salzburg"
 ---
-
 [Ekaterina Akimova-Höpner](https://www.linkedin.com/in/ekaterina-akimova-7727801a6/), founder of the [R-Ladies Salzburg](https://www.meetup.com/rladies-salzburg/) chapter, recently spoke with the R Consortium about using R to support cutting-edge cancer research and building a local R community in Austria. Ekaterina shared how she uses R for data preprocessing, statistical modeling, and visualizing high-dimensional genomic datasets. She discussed the launch of R-Ladies Salzburg in 2024, the importance of hands-on workshops for early-career researchers, and how scientific collaboration continues to shape her approach to community building. She also highlighted her talk last year at the useR! Conference 2024, where she presented tools for reproducible research in biomedical science.
 
-![](EkaterinaAkimova.png){width=50%}
+![](EkaterinaAkimova.png){width=50% fig-alt="Ekaterina Akimova-Höpner, founder of R-Ladies Salzburg"}
 
 ## Please share your background and involvement with the RUGS group.
 
@@ -27,13 +25,13 @@ At that time, it felt right to organize a group explicitly focused on supporting
 
 In our first year, 2024, I planned and organized four meetups, ranging from beginner R workshops to networking events. During this time, I connected with members and organizers from all over the world, which was an enriching experience. I was fortunate to be involved in organizing last year's useR! conference, which took place in Salzburg. One of my most rewarding moments was presenting my R package, which is in development for analyzing amplicon sequence data. I was honored to receive the Best Poster award, and the positive feedback I received strengthened my desire to give back to the community and support others on their R journey.
 
-![](useR2024Conference.png){width=50%}
+![](useR2024Conference.png){width=50% fig-alt="Ekaterina Akimova-Höpner receiving Best Poster award at useR! 2024 conference in Salzburg, Germany"}
 
 Being part of the R-Ladies global community has broadened my horizons, and I have improved my public speaking, mentorship, and event organization skills. 
 
 ## Can you share what the R community is like in Austria? 
 
-![](RLadiesSalzburgLogo.png){width=50%}
+![](RLadiesSalzburgLogo.png){width=50% fig-alt="R Ladies Salzburg logo"}
 
 R is actively used in various fields, particularly in academia and banking. While there are several user groups in Austria, they are mainly concentrated in the eastern part of the country, with Salzburg having a smaller presence. For instance, the [Vienna R User Group](https://www.meetup.com/viennar/), along with [R-Ladies Vienna](https://www.meetup.com/rladies-vienna/), represents a large community with which I've had the pleasure of connecting. However, organizing in-person events in the western region, particularly in Salzburg, is still a challenge. I see an opportunity to facilitate in-person meetings for those living in this area, helping to grow the local community. 
 
@@ -45,7 +43,7 @@ The first challenge we faced was working with the Meetup platform, which is the 
 
 Let me share my project on detecting complex rearrangements in next-generation sequencing data. The project aims to create a tool for detecting and characterizing complex genomic rearrangements, specifically templated sequence insertions, duplications, and inversions, using next-generation sequencing data. Previous studies have demonstrated that aberrant DNA double-strand break repair is a common feature in various types of cancer. In our earlier research, we discovered that these breaks can lead to genomic alterations that are not captured by standard variant-calling tools currently in use. For instance, we found evidence that high intracellular dNTP levels, observed in SAMHD1-deficient cells, promote increased templated sequence insertions.
 
-![](NGSDataProject.png)
+![](NGSDataProject.png){fig-alt="Diagram of NGS Data Project for detecting complex rearrangements in next-generation sequencing data"}
 
 To quantify and characterize these events, we needed a pipeline capable of handling these datasets and performing filtering, characterization, and visualization. I chose to use R for this task because I felt more confident programming in R at the time. I developed an R-based pipeline utilizing packages from Bioconductor, including [IRanges](https://bioconductor.org/packages/release/bioc/html/IRanges.html) and [GenomicRanges](https://bioconductor.org/packages/release/bioc/html/GenomicRanges.html), along with base R and the [Tidyverse](https://www.tidyverse.org/).
 

--- a/posts/ics-funded-grant-secure-tls-connections-in-{nanotext}-and-{mirai}-facilitating-high-performance-computing-in-the-life-sciences/index.qmd
+++ b/posts/ics-funded-grant-secure-tls-connections-in-{nanotext}-and-{mirai}-facilitating-high-performance-computing-in-the-life-sciences/index.qmd
@@ -8,8 +8,7 @@ format: html
 url: "https://r-consortium.org/posts/ics-funded-grant-secure-tls-connections-in-{nanotext}-and-{mirai}-facilitating-high-performance-computing-in-the-life-sciences/"
 unpublished: false
 categories: ["isc", "announcements", "pharma", "ai", "infrastructure"]
-image-alt: "ISC-funded Grant: Secure TLS Connections in {nanonext} and {mirai} Facilitating High-Performance Computing in the Life Sciences"
-
+image-alt: "Logos for {nanonext}, an R binding to the state-of-the-art C messaging library NNG (Nanomsg Next Generation), created as a successor to ZeroMQ, and {mirai}, a package that enables asynchronous evaluation in R, built on top of {nanonext}"
 ---
 <style>
   .anchorjs-link {
@@ -23,7 +22,7 @@ _Contributed by Charlie Gao, Director at Hibiki AI Limited_
 
 
 <div style="text-align: center;">
-  <img src="mirai.webp" alt="Mirai Nano Next" >
+  <img src="mirai.webp" alt="Logos for {nanonext}, an R binding to the state-of-the-art C messaging library NNG (Nanomsg Next Generation), created as a successor to ZeroMQ, and {mirai}, a package that enables asynchronous evaluation in R, built on top of {nanonext}" >
 </div>
 
 
@@ -46,7 +45,7 @@ With the seed planted in {nanonext}, {mirai} and {crew} have grown to form an el
 
 
 <div style="text-align: center;">
-  <img src="charlie.webp" alt="Charlie Gao" style="width:556px; height:423.516px; object-fit:contain;">
+  <img src="charlie.webp" alt="Charlie Gao, Director at Hibiki AI Limited" style="width:556px; height:423.516px; object-fit:contain;">
   <p>Charlie Gao, Director at Hibiki AI Limited</p>
 </div>
 

--- a/posts/identifying-measles-immunity-gaps-in-the-us/index.qmd
+++ b/posts/identifying-measles-immunity-gaps-in-the-us/index.qmd
@@ -5,12 +5,10 @@ description: "Explore Iko Musa's student competition-winning analysis on US meas
 author: "R Consortium"
 categories: ["r/medicine 2025", "epidemiology", "north america"]
 image: "thumbnail-iko-musa-student-competition-winner.png"
-image-alt: "Identifying Measles Immunity Gaps in the US: A Comprehensive Analysis by Iko Musa"
+image-alt: "Lightning talk from Iko Musa - student competition winner at R/Medicine 2025"
 date: "06/19/2025"
 url: "https://r-consortium.org/posts/identifying-measles-immunity-gaps-in-the-us/"
-
 ---
-
 # Identifying Measles Immunity Gaps in the US: A Comprehensive Analysis by Iko Musa
 
 {{< video https://www.youtube.com/embed/LKNOEayXstU >}}

--- a/posts/igniting-an-r-movement-in-the-philippines-rnvsus-open-science-vision/index.qmd
+++ b/posts/igniting-an-r-movement-in-the-philippines-rnvsus-open-science-vision/index.qmd
@@ -6,13 +6,12 @@ description: "Dr. Orville D. Hombrebueno, Romnick Pascua, Mer Joseph Q. Carranza
 categories: ["rugs", "software development","asia"]
 author: "R Consortium"
 image: "RNVSULogo.png"
-image-alt: "picture of RNVSU Logo"
+image-alt: "Logo for R User Group of Nueva Vizcaya State University (RNVSU), Philippines"
 date: "03/11/2026"
 ---
-
 [Dr. Orville D. Hombrebueno](https://www.linkedin.com/in/orville-hombrebueno-1725a8276/), [Romnick Pascua](https://www.linkedin.com/in/romnick-pascua-00424536/), [Mer Joseph Q. Carranza](https://www.linkedin.com/in/mer-joseph-caranza-19182b24a/), [Richard J. Taclay](https://scholar.google.com/citations?user=D2as-VkAAAAJ&hl=en), and Mart Jasper G. Antonio, organizers of the [R User Group of Nueva Vizcaya State University](https://www.meetup.com/r-nvsu/) (RNVSU) recently spoke with the R Consortium about building a provincial, university-based R community in the Philippines. They shared how the group evolved from a handful of faculty members independently using R for theses, mathematical modeling, biodiversity research, and land-use analysis into a funded initiative promoting reproducible research and open science. The team discussed launching foundational workshops, introducing GitHub and Quarto workflows, organizing hybrid events for their university’s charter anniversary, and envisioning dashboards and data-driven tools to support local education, agriculture, and research.
 
-![](RNVSULogo.png){width="50%"}
+![](RNVSULogo.png){width="50%" fig-alt="Logo for R User Group of Nueva Vizcaya State University (RNVSU), Philippines"}
 
 **Please share about your background and involvement with the RUGS group.**
 
@@ -52,7 +51,7 @@ The RUGS community provides a meaningful space for exchanging ideas, exploring a
 
 I believe this group will broaden my knowledge and hone my skills in data analysis and mathematical computations. Now, I am exploring model development and geographic visualizations in R, which are among R's strengths compared to other computational software. Moreover, it is an honor to be one of the founders of this group, as it serves as a platform to support and help students, academicians, scholars, teachers, and researchers in their academic and professional endeavors.
 
-![](RNVSUMeetup.png)
+![](RNVSUMeetup.png){fig-alt="Participants from the R User Group of Nueva Vizcaya State University (RNVSU), Philippines"}
 
 **Can you share what the R community is like in the Philippines?**
 

--- a/posts/improving-with-r-kylie-bemis-unveils-enhanced-signal-processing-with-matter-2-4-upgrade/index.qmd
+++ b/posts/improving-with-r-kylie-bemis-unveils-enhanced-signal-processing-with-matter-2-4-upgrade/index.qmd
@@ -8,7 +8,7 @@ unpublished: false
 categories: ["rugs", "events", "infrastructure", "women in tech"]
 
 ---
-![](images/kylie-bemis-matter.png)
+![](images/kylie-bemis-matter.png){fig-alt="Kylie Bemis, assistant teaching professor at the Khoury College of Computer Sciences at Northeastern University - Enhanced signal processing with Matter 2.4 upgrade"}
 
 The R Consortium recently connected with [Kylie Bemis](https://www.khoury.northeastern.edu/people/kylie-ariel-bemis/), assistant teaching professor at the Khoury College of Computer Sciences at Northeastern University. She has a keen interest in statistical computing frameworks and techniques for analyzing intricate data, particularly focusing on datasets with complex correlation patterns or those that amalgamate data from various origins. 
 

--- a/posts/introducing-aggrecat-mathematical-aggregation-expert-judgements/index.qmd
+++ b/posts/introducing-aggrecat-mathematical-aggregation-expert-judgements/index.qmd
@@ -6,7 +6,7 @@ description: "aggreCAT is an open-source R package hosted on CRAN designed for m
 categories: ["isc", "software development"]
 date: "06/23/2026"
 image: "img_IDEA_repliCATS.png"
-image-alt: "IDEA elicitation workflow used by repliCATS: Investigate, Discuss, Estimate, and Aggregate expert judgments"
+image-alt: "replicCATS graphic of the IDEA Protocol: Investigate-Discuss-Estimate-Aggregate"
 bibliography: ISC_blog.bib
 csl: cell.csl
 date-modified: last-modified
@@ -17,7 +17,6 @@ author:
   - name: Elliot Gould
     orcid: 0000-0002-6585-538X
 ---
-
 ```{r}
 #| label: setup
 #| include: false

--- a/posts/introducing-r-to-malawi-a-community-in-the-making/index.qmd
+++ b/posts/introducing-r-to-malawi-a-community-in-the-making/index.qmd
@@ -7,13 +7,11 @@ date: "12/30/2024"
 url: "https://r-consortium.org/posts/introducing-r-to-malawi-a-community-in-the-making/"
 unpublished: false
 categories: ["rugs", "events", "africa"]
-image-alt: "Introducing R to Malawi: A Community in the Making"
-
+image-alt: "R Users Malawi logo"
 ---
-
 David Mwale, the [R Users Malawi](https://www.meetup.com/r-users-malawi/) group organizer, recently spoke with the R Consortium about his efforts to establish and grow the R community in Malawi. David shared insights into the group's inaugural meeting, the excitement surrounding R among researchers and students, and his plans to engage academic institutions through online and in-person events. He also discussed the challenges of introducing R in a region where other tools like Stata and SPSS dominate and his vision for fostering a vibrant and supportive R ecosystem in Malawi.
 
-![](DavidMwale.png){width=50%}
+![](DavidMwale.png){width=50% fig-alt="David Mwale, the R Users Malawi group organizer,"}
 
 **Please share your background and involvement with the RUGS group.**
 
@@ -27,7 +25,7 @@ The use of R in Malawi is still in its infancy and is not widely adopted. For in
 
 One issue may be that academic institution lecturers themselves still need to become familiar with R. They tend to teach what they already know, which might limit students' exposure to more modern tools. A colleague of mine, pursuing his studies at an institution in Malawi, mentioned that they still use Stata for their master's dissertation. Again, while this is acceptable, R offers more advantages.
 
-![](RUsersMalawi.png){width=50%}
+![](RUsersMalawi.png){width=50% fig-alt="R Users Malawi logo"}
 
 **How was the response to your first event? How did you promote the event?** 
 

--- a/posts/investing-in-the-r-community-our-support-for-global-r-events-in-2026/index.qmd
+++ b/posts/investing-in-the-r-community-our-support-for-global-r-events-in-2026/index.qmd
@@ -6,11 +6,10 @@ description: "In 2026, the R Consortium is supporting global R events and commun
 categories: ["top level projects", "events", "announcements"]
 author: "R Consortium"
 image: "eurobioc2026.png"
-image-alt: "event logos for R community events in 2026"
+image-alt: "Participants from previous EuroBioC conference"
 date: "04/15/2026"
 lightbox: true
 ---
-
 The R ecosystem continues to grow because of its community - organizers, educators, and practitioners who create spaces for collaboration and learning. These efforts often happen independently, across regions and domains, yet collectively they shape the future of R.
 
 At the R Consortium, we actively invest in that layer of the ecosystem. In 2026, we are committed to support R-related events and community initiatives worldwide, with a particular focus on strengthening independent, community-led conferences and user groups.
@@ -26,13 +25,13 @@ As part of this annual initiative, we support important R-related events listed 
 
 ## [EuroBioC 2026](https://eurobioc2026.bioconductor.org/)
 
-![](eurobioc2026.png)
+![](eurobioc2026.png){fig-alt="Participants from previous EuroBioC conference"}
 
 EuroBioC focuses on the Bioconductor ecosystem and the use of R in bioinformatics and computational biology. It is being held in Turku, Finland, during the first week of June. It connects scientists working on genomics, proteomics, and related fields, highlighting how R supports cutting-edge research in the life sciences.
 
 ## [Rencontres R 2026](https://astamm.github.io/en/rr2026.html)
 
-![](rencontresr2026.png)
+![](rencontresr2026.png){fig-alt="Logo for Rencontres 2026, organized by the French Statistical Society (SFdS)"}
 
 Rencontres is a long-running conference rooted in the French-speaking R community. It is organized by the French Statistical Society (SFdS) and brings together researchers, public sector professionals, and industry practitioners to share applied work and foster collaboration. Its regional focus helps strengthen R adoption across Europe while maintaining strong technical depth. Rencontres is open to beginners as well as experienced users from all sectors and is being held June 16-18 in Nantes, France.
 
@@ -48,7 +47,7 @@ Registration deadline: Friday, May 29, 2026
 
 ## [Cascadia R Conference](https://cascadiarconf.com/)
 
-![](cascadiar2026.png){width=30%}
+![](cascadiar2026.png){width=30% fig-alt="CascadiaR conference 2026 logo, Portland, Oregon"}
 
 The Cascadia R Conference serves the Pacific Northwest in the US, with a strong emphasis on practical data science and community engagement. It is held in Portland, OR, running over two days on June 26-27. Cascadia R is known for being accessible, welcoming, and highly relevant to both new and experienced R users working in industry and academia.
 
@@ -64,7 +63,7 @@ Registration deadline: Fri, June 12, 2026
 
 ## [useR! 2026](https://user2026.r-project.org/)
 
-![](userbam2026.png){width=30%}
+![](userbam2026.png){width=30% fig-alt="useR! 2026 logo, July 6 - 9, 2026 in Warsaw, Poland"}
 
 The useR! 2026 conference is the flagship global gathering of the R community, taking place this year July 6 - 9, 2026 in Warsaw, Poland. It brings together data scientists, statisticians, developers, and researchers from around the world for keynote talks, hands-on workshops, and community-driven sessions that showcase cutting-edge applications and developments in the R ecosystem.
 
@@ -81,18 +80,18 @@ Nomination deadline: Fri, April 24, 2026
 
 ## [Ghana R Conference](https://ghana-rusers.org/ghana-r-conference-2026/)
 
-![](ghanar2026.png){width=30%}
+![](ghanar2026.png){width=30% fig-alt="GhanaR 2026 conference logo"}
 
 The Ghana R Conference 2026, organized by the Ghana R Users Community, will take place July 9 - 10, 2026, at Accra Technical University in Accra, bringing together data scientists, researchers, and practitioners to explore the role of R in advancing Ghana’s digital transformation. Centered on the theme of using R to support AI and data-driven development, the event features talks, workshops, and community engagement aimed at building local expertise and strengthening the data science ecosystem across Ghana and the broader African region.
 
 ## [LatinR](https://latinr.org/)
 
-![](latinr-main-image.png)
+![](latinr-main-image.png){fig-alt="Photos from previous LatinR - credit: Comunicación FCEA"}
 _photo credit: [Comunicación FCEA](https://www.flickr.com/people/comunicacionfcea/)_
 
 LatinR is one of the most important R conferences in Latin America. It provides a platform for Spanish- and Portuguese-speaking communities to share knowledge, present research, and build connections across countries. Its regional focus helps drive adoption and innovation in fast-growing data science markets.
 
-![](latinr-logo.png){width=38%}
+![](latinr-logo.png){width=38% fig-alt="LatinR 2026 conference logo"}
 
 LatinR is being held in November 11-13, 2026. Don't miss it!
 

--- a/posts/jeremy-horne-on-building-inclusive-r-communities-across-the-uk/index.qmd
+++ b/posts/jeremy-horne-on-building-inclusive-r-communities-across-the-uk/index.qmd
@@ -6,13 +6,12 @@ description: "Jeremy Horne, organizer of the Birmingham R User Group and founder
 categories: ["rugs", "software development"]
 author: "R Consortium"
 image: "BirminghamRUGMeetup1.png"
-image-alt: "picture of Birmingham RUG Organizer"
+image-alt: "Jeremy Horne on Building Inclusive R Communities Across the UK"
 date: "03/02/2026"
 ---
-
 [Jeremy Horne](https://www.linkedin.com/in/jeremy-horne-datacove/?originalSubdomain=uk), organizer of the [Birmingham R User Group](https://www.meetup.com/birminghamr/) and founder of the data and analytics consultancy [Datacove](https://datacove.co.uk/), recently spoke with the R Consortium about rebuilding Birmingham’s R community as an inclusive space for learning and collaboration. Drawing on Datacove’s experience supporting R user groups across the UK, Jeremy discussed the Birmingham group's relaunch post-COVID and how bringing R and Python users together has strengthened participation across industries. He reflected on the importance of cross-language collaboration, welcoming freelancers and early-career practitioners, and creating community-led meetups that translate shared knowledge into real professional opportunities.
 
-![](JeremyHorne.png){width=50%}
+![](JeremyHorne.png){width=50% fig-alt="Jeremy Horne, organizer of the Birmingham R User Group and founder of the data and analytics consultancy Datacove"}
 
 **Please share about your background and involvement with the RUGS group.**
 
@@ -30,7 +29,7 @@ My journey transitioned from consulting to exploring the marketing field in 2014
 
 I wanted to help people work more efficiently with data. Many view data as a cost, but I believe it is an investment in the business. When you invest in data analysis, it pays off by revealing insights that drive growth. Some people say "data is the new oil," but at Datacove, we prefer "data is the new soil" because it nurtures and enables your business to grow.
 
-![](BirminghamRUGOrganizers.png)
+![](BirminghamRUGOrganizers.png){fig-alt="Birmingham RUG organizers sharing a toast"}
 
 **Can you share what the R community is like in the United Kingdom in general and in Birmingham specifically?**
 
@@ -40,7 +39,7 @@ In Birmingham, the predominant industries using R include pharmaceuticals, healt
 
 Birmingham's R community is still evolving and rebuilding. It tends to be one of our more junior communities, and we are actively working to bring more people back into the Birmingham R scene. We see a good mix of attendees, many of whom are freelancers. These individuals are often curious and eager to learn, but may not have a large team to support them. The community atmosphere provides them with a sense of belonging and peer support to discuss their challenges.
 
-![](BirminghamRUGMeetup1.png)
+![](BirminghamRUGMeetup1.png){fig-alt="Picture of audience from Birmingham RUG meetup"}
 
 I remember a comment from someone at EARL two years ago. He works in data and tech, doesn't primarily use R, but decided to attend EARL out of interest. By the end of the conference, he expressed surprise at how helpful, friendly, and supportive the R community is, even for someone new to it. Everyone there is eager to help one another, whether it’s providing guidance or assisting someone in advancing their career.
 
@@ -60,7 +59,7 @@ Our goal is to host quarterly meetups this year. We already have a schedule for 
 
 Although we haven't organized many meetups in Birmingham, we have a couple of champions in the area who are strong supporters of the community. They are actively helping us revitalize the group as best as they can.
 
-![](BirminghamRUGMeetup2.png)
+![](BirminghamRUGMeetup2.png){fig-alt="Audience members networking from Birmingham RUG meetup"}
 
 **How do you approach community building across multiple cities, and what tools or platforms help you keep people connected between events?**
 

--- a/posts/johnson-and-johnsons-success-story-a-hybrid-r-sas-strategy-for-fda-submission/index.qmd
+++ b/posts/johnson-and-johnsons-success-story-a-hybrid-r-sas-strategy-for-fda-submission/index.qmd
@@ -7,15 +7,13 @@ author: "R Consortium"
 categories: ["submissions", "pharma", "members", "working groups"]
 image: "jnj-submissions-main-image.png"
 date: "12/15/2025"
-image-alt: "Johnson & Johnson’s Success Story: A Hybrid R/SAS Strategy for FDA Submission"
-
+image-alt: "R Consortium webinar - Johnson & Johnson (J&J) case study of their successful “Hybrid R/SAS” submission strategy to the FDA - All 3 speakers pictured: Alicia Humphreys, Steven Haesendonckx, and Linshan Yuan"
 ---
-
 The pharmaceutical industry is currently navigating a significant shift toward open-source programming, with R becoming an increasingly vital tool for regulatory submissions. In a recent R Consortium webinar, Johnson & Johnson (J\&J) shared a detailed case study of their successful "Hybrid R/SAS" submission strategy to the FDA.
 
 Presented by Alicia Humphreys, Steven Haesendonckx, and Linshan Yuan, the presentation outlines how J\&J leveraged the strengths of both languages to achieve FDA approval, offering a roadmap for other organizations looking to modernize their submission pipelines.
 
-![](jnj-submissions-main-image.png)
+![](jnj-submissions-main-image.png){fig-alt="R Consortium webinar - Johnson & Johnson (J&J) case study of their successful “Hybrid R/SAS” submission strategy to the FDA - All 3 speakers pictured: Alicia Humphreys, Steven Haesendonckx, and Linshan Yuan"}
 
 ### **The Hybrid Strategy: Best of Both Worlds**
 

--- a/posts/join-our-r-medicine-webinar-quarto-for-reproducible-medical-manuscripts/index.qmd
+++ b/posts/join-our-r-medicine-webinar-quarto-for-reproducible-medical-manuscripts/index.qmd
@@ -9,7 +9,7 @@ categories: ["submissions", "pharma", "events"]
 
 ---
 
-![](DataTrail and its Extensions (1).png)
+![](DataTrail and its Extensions (1).png){fig-alt="R Consortium webinar - \"Quarto for Reproducible Medical Manuscripts,\" held March 20, 2024, featuring speaker Mine Cetinkaya-Rundel, Professor of the Practice of Statistical Science at Duke University"}
 
 Join the R Consortium for an enlightening webinar on March 20th, 2024, at 4:00 PM ET, featuring Mine Cetinkaya-Rundel, Professor of the Practice of Statistical Science at Duke University. Discover the innovative Quarto tool to streamline the creation of reproducible, publication-ready manuscripts.
 

--- a/posts/join-our-upcoming-webinar-master-tidy-finance-access-financial-data-with-expert-christoph-scheuch/index.qmd
+++ b/posts/join-our-upcoming-webinar-master-tidy-finance-access-financial-data-with-expert-christoph-scheuch/index.qmd
@@ -7,11 +7,9 @@ date: "02/06/2024"
 url: "https://r-consortium.org/posts/join-our-upcoming-webinar-master-tidy-finance-access-financial-data-with-expert-christoph-scheuch/"
 unpublished: false
 categories: ["events"]
-image-alt: "Join Our Upcoming Webinar: Master Tidy Finance & Access Financial Data with Expert Christoph Scheuch"
-
+image-alt: "R Consortium webinar - \"Tidy Finance & Accessing Financial Data,\" held March 6, 2024, featuring speaker Christoph Scheuch, Head of Artificial Intelligence, wikifolio Financial Technologies AG"
 ---
-
-![](images/tidy-finance-webinar.png)
+![](images/tidy-finance-webinar.png){fig-alt="R Consortium webinar - \"Tidy Finance & Accessing Financial Data,\" held March 6, 2024, featuring speaker Christoph Scheuch, Head of Artificial Intelligence, wikifolio Financial Technologies AG"}
 
 Are you passionate about financial economics and eager to learn more about empirical research methods? Then our upcoming webinar is an unmissable opportunity for you!
 

--- a/posts/julia-silge-on-fostering-a-technical-inclusive-r-community-in-salt-lake-city/index.qmd
+++ b/posts/julia-silge-on-fostering-a-technical-inclusive-r-community-in-salt-lake-city/index.qmd
@@ -9,10 +9,9 @@ image: "JuliaSilge-main-image.png"
 image-alt: "image of Julie Silge co-organizer of Salt Lake City R User Group" 
 date: "07/029/2025"
 ---
-
 [Julia Silge](https://www.linkedin.com/in/juliasilge/), co-organizer of the [Salt Lake City R User Group](https://www.meetup.com/slc-rug/), recently talked to the R Consortium about sustaining an active R community in a region without a central tech hub. Julia shared how she discovered R and became deeply engaged with its open-source ecosystem. She discussed the group’s dual-format meetups, which include remote talks streamed via YouTube and quarterly in-person gatherings, as well as efforts to make the community inclusive for both local professionals and a wider audience. She also highlighted a recent session on advanced Git practices and an upcoming talk on sparse data structures in the tidymodels framework.
 
-![](JuliaSilge.png)
+![](JuliaSilge.png){fig-alt="image of Julie Silge co-organizer of Salt Lake City R User Group"}
 
 ## Please share your background and involvement with the RUGS group.
 
@@ -65,7 +64,7 @@ For instance, with text data, certain words are used frequently while many other
 
 This upcoming talk will explain how sparse data structures are integrated into the tidymodels framework, emphasizing the efficiency gains that can be achieved. By using sparse data structures, we can handle larger models that might otherwise be impossible to train on a standard computer due to memory constraints. I’m looking forward to this informative session!
 
-![](SaltLakeCityOnlineMeetup.png)
+![](SaltLakeCityOnlineMeetup.png){fig-alt="Salt Lake City members during online meetup"}
 
 ## Any techniques you recommend using for planning for or during the event? (Github, zoom, other) Can these techniques be used to make your group more inclusive to people that are unable to attend physical events in the future?
 

--- a/posts/kolkata-r-user-group-a-rich-history-with-statistics/index.qmd
+++ b/posts/kolkata-r-user-group-a-rich-history-with-statistics/index.qmd
@@ -7,19 +7,17 @@ date: "07/12/2024"
 url: "https://r-consortium.org/posts/kolkata-r-user-group-a-rich-history-with-statistics/"
 unpublished: false
 categories: ["rugs", "events", "asia"]
-image-alt: "Kolkata R User Group: A Rich History with Statistics"
-
+image-alt: "Samrit Pramanik, manager of Kolkata R User Group, India"
 ---
-
 The R Consortium recently spoke with [Samrit Pramanik](https://samrit.quarto.pub/) of the [Kolkata R User Group](https://www.meetup.com/kolkata-r-user-group/) about his experience starting a new R User Group in India. Samrit highlighted Kolkata’s rich history with statistics and talked about the diverse local R community.
 
 
-![](Samrit.jpg){width=50%}
+![](Samrit.jpg){width=50% fig-alt="Samrit Pramanik, manager of Kolkata R User Group, India"}
 
 
 The Kolkata R User group is organizing its second online event titled “[A New Approach for Teaching Data Analytics with R](https://www.meetup.com/kolkata-r-user-group/events/301528636/)” on July 13th. R users from around the world are invited to join this event.
 
-![](Announcement.jpg)
+![](Announcement.jpg){fig-alt="Announcement for Kolkata R User Group second online event titled “A New Approach for Teaching Data Analytics with R,” held on July 13, 2024"}
 
 
 **_Please share your background and involvement with the RUGS group._**
@@ -31,7 +29,7 @@ This is the third city-based R user group in India that is affiliated with the R
 **_Can you share what the R community is like in Kolkata?_**
 
 
-![](KolkotaLogo.jpg){width=50%}
+![](KolkotaLogo.jpg){width=50% fig-alt="Kolkata R User Group logo"}
 
 
 The Kolkata User Group has been formed with a broader perspective that I would like to share with you. Kolkata is known for its reputation in statistical research and education. The city is recognized as the birthplace of modern statistics in India, with the establishment of the [Indian Statistical Institute](https://www.isical.ac.in/) (ISI) in 1931 by a prominent figure in statistics. The University of Calcutta, where I graduated, was the first in Asia to offer a post-graduate degree in statistics in 1941. This rich history made the formation of the Kolkata R User Group inevitable. Our community consists of academics and professionals from diverse fields such as life sciences, healthcare, the public sector, physics, astrophysics, and other industries. This diverse background facilitates robust exchanges of ideas and techniques related to R and data, making our R community in Kolkata truly unique.
@@ -50,7 +48,7 @@ We have received very positive feedback and responses from the participants who 
 Currently, I am working on two projects. The first project involves cricket analytics, where I extensively use R for cleaning up messy raw data and conducting exploratory data analysis at both the team and individual player levels and published a [shiny dashboard](https://samritpramanik.shinyapps.io/T20PerformAnalysis/) on performance analysis of T20I players. I’m also building a statistical model to predict the total score of an innings, the winner of the match, and the tournament. Lastly, I aim to compile all the findings into an ebook format.
 
 
-![](Dashboard.png)
+![](Dashboard.png){fig-alt="Screenshot from Cricket Performance Analysis Shiny dashboard"}
 
 
  Cricket Performance Analysis Shiny Dashboard

--- a/posts/looking-forward-to-seeing-you-at-useR2025-this-year/index.qmd
+++ b/posts/looking-forward-to-seeing-you-at-useR2025-this-year/index.qmd
@@ -7,11 +7,9 @@ date: "03/14/2025"
 url: "https://r-consortium.org/posts/looking-forward-to-seeing-you-at-useR2025-this-year/"
 unpublished: false
 categories: ["pharma", "events", "infrastructure", "asia"]
-image-alt: "Looking forward to seeing you at useR! 2025 this year!"
-
+image-alt: "useR! 2025 conference logo"
 ---
-
-![](user2025_conf_logo.png)
+![](user2025_conf_logo.png){fig-alt="useR! 2025 conference logo"}
 
 ### [Registration is now open!](https://user2025.r-project.org/register)
 


### PR DESCRIPTION
## Summary
- Applies 55 reviewed CSV rows (F0191–F0259) across 16 blog posts
- Covers R-Ladies Zurich, HTA working group, cancer research Austria, nanonext/mirai ISC grant, RNVSU Philippines, Kylie Bemis matter, repliCATS, Malawi RUG, 2026 event sponsorship, Birmingham RUG, J&J FDA submission, tidy-finance webinar, Julia Silge SLC, Kolkata RUG, and useR! 2025

## Safeguards
- Verified no duplicate YAML `image-alt` keys
- Verified front matter closing `---` delimiters intact

## Test plan
- [ ] GitHub Pages build completes
- [ ] Spot-check HTML img alt on nanonext/mirai ISC grant post
- [ ] Verify investing-in-the-r-community 2026 event images