### PR TITLE
Fix aggrecat post CI render (freeze: true)

### DIFF
--- a/posts/introducing-aggrecat-mathematical-aggregation-expert-judgements/index.qmd
+++ b/posts/introducing-aggrecat-mathematical-aggregation-expert-judgements/index.qmd
@@ -7,6 +7,7 @@ categories: ["isc", "software development"]
 date: "06/23/2026"
 image: "img_IDEA_repliCATS.png"
 image-alt: "replicCATS graphic of the IDEA Protocol: Investigate-Discuss-Estimate-Aggregate"
+freeze: true
 bibliography: ISC_blog.bib
 csl: cell.csl
 date-modified: last-modified


### PR DESCRIPTION
## Summary
- Sets `freeze: true` on the aggrecat blog post
- Prevents GitHub Pages from re-executing R chunks (requires `fansi`, `aggreCAT`, etc.) when only YAML/metadata changes
- Uses existing `_freeze/posts/introducing-aggrecat-.../` cached output

## Context
Batch 5 updated `image-alt` in front matter, which invalidated `freeze: auto` and caused CI to re-run the setup chunk, failing on missing `fansi`.

## Test plan
- [ ] GitHub Pages build completes past post 133/299