### PR TITLE
Make ISC proposal template required

### DIFF
--- a/all-projects/callforproposals.qmd
+++ b/all-projects/callforproposals.qmd
@@ -48,9 +48,9 @@ To apply for an ISC grant please continue with the instructions below. To seek f
 
 Please provide a 2 to 5 page proposal that describes the problem you want to solve. 
 
-:::{.callout-tip}
+:::{.callout-note}
 ## Use Our Template
-We encourage you to use our [proposal template](https://github.com/RConsortium/isc-proposal). The template includes detailed guidance and examples for each section.
+Our [proposal template](https://github.com/RConsortium/isc-proposal) includes detailed guidance and examples for each section.
 :::
 
 The ISC has a limited grant budget, and we want to ensure that funded projects deliver the maximum benefit to the community. Successful proposals show well-defined milestones, with initial work completed to minimize delivery risk, e.g., upfront research and well-defined action plans.
@@ -59,7 +59,7 @@ We encourage you to seek feedback from the community before formally submitting 
 
 ## How to Apply
 
-1. **Prepare your proposal** using our [template](https://github.com/RConsortium/isc-proposal)
+1. **Prepare your proposal** using our required [template](https://github.com/RConsortium/isc-proposal)
 2. **Create a self-contained PDF** of your completed proposal
 3. **Submit through our form** at [forms.gle/o1nhNrdzebQc2DNU6](https://forms.gle/o1nhNrdzebQc2DNU6) (requires Google Account)
 4. **Confirm submission** - you'll see "Thank you for your proposal!" and receive a confirmation email


### PR DESCRIPTION
Our experience with the template has been good. It has made it easier for us to get the information we are looking for. Proposals deviating from the template have typically not provided additional info which we would want to extend the template with.